### PR TITLE
Support Content-Type preflight requests to rest server when using --unsafe-cors flag

### DIFF
--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -77,7 +77,7 @@ func (rs *RestServer) Start(listenAddr string, maxOpen int, readTimeout, writeTi
 
 	var httpHandler http.Handler = rs.Mux
 	if cors {
-		return tmrpcserver.Serve(rs.listener, handlers.CORS()(httpHandler), rs.log, cfg)
+		return tmrpcserver.Serve(rs.listener, handlers.CORS(handlers.AllowedHeaders([]string{"Content-Type"}))(httpHandler), rs.log, cfg)
 	}
 
 	return tmrpcserver.Serve(rs.listener, httpHandler, rs.log, cfg)


### PR DESCRIPTION
Support preflight requests triggered by the Content-Type header to the rest server when `--unsafe-cors` flag is used.

When making a request to the rest server from a web browser, if the request includes a Content-Type other than those listed [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests), it will trigger a preflight request.

That request currently fails with a `403` status code.

After this change, it will return `200`.

Right now, if a user is running localterra on their development machine and uses terra.js to make a POST request (e.g. `/txs/estimate_fee` via [estimateFee](https://github.com/terra-money/terra.js/blob/7bbff355d74e40ff9e558ab7791b5c1c6dfa4640/src/client/lcd/api/TxAPI.ts#L270)), that request will trigger a preflight request and fail. It will fail because it will have been triggered by the `Content-Type: application/json` header on the request (added by axios automatically because of the payload). The request will have the `Access-Control-Request-Headers: content-type` header, which is not supported by [default](https://github.com/gorilla/handlers/blob/8a3748addc242fc560bd6d4ff28b0374c010b1b4/cors.go#L31) by the middleware that handles CORS (`handlers`). This is mentioned in a comment [here](https://github.com/gorilla/handlers/blob/8a3748addc242fc560bd6d4ff28b0374c010b1b4/cors.go#L191-L192). 

## Summary of changes

Configure CORS middleware to allow `Content-Type`.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
