### PR TITLE
[Bugfix] fix panic at wasm event parse

### DIFF
--- a/x/wasm/types/connector.go
+++ b/x/wasm/types/connector.go
@@ -26,16 +26,18 @@ func ParseEvents(
 
 	var sdkEvents sdk.Events
 
-	sdkEvent, err := buildEvent(EventTypeWasmPrefix, contractAddr, attributes)
-	if err != nil {
-		return nil, err
+	if len(attributes) != 0 {
+		sdkEvent, err := buildEvent(EventTypeWasmPrefix, contractAddr, attributes)
+		if err != nil {
+			return nil, err
+		}
+
+		sdkEvents = sdkEvents.AppendEvent(*sdkEvent)
+
+		// Deprecated: from_contract
+		sdkEvent.Type = EventTypeFromContract
+		sdkEvents = sdkEvents.AppendEvent(*sdkEvent)
 	}
-
-	sdkEvents = sdkEvents.AppendEvent(*sdkEvent)
-
-	// Deprecated: from_contract
-	sdkEvent.Type = EventTypeFromContract
-	sdkEvents = sdkEvents.AppendEvent(*sdkEvent)
 
 	// append wasm prefix for the events
 	for _, event := range events {

--- a/x/wasm/types/connector_test.go
+++ b/x/wasm/types/connector_test.go
@@ -73,6 +73,47 @@ func TestParseEvents(t *testing.T) {
 	)}, events)
 }
 
+func TestParseEventsWithoutAttributes(t *testing.T) {
+	_, _, addr := keyPubAddr()
+
+	events, err := ParseEvents(addr, wasmvmtypes.EventAttributes{}, wasmvmtypes.Events{
+		{
+			Type: "type1",
+			Attributes: wasmvmtypes.EventAttributes{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+				{Key: "key3", Value: "value3"},
+			},
+		},
+		{
+			Type: "type2",
+			Attributes: wasmvmtypes.EventAttributes{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+				{Key: "key3", Value: "value3"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, sdk.Events{sdk.NewEvent(
+		fmt.Sprintf("%s-type1", EventTypeWasmPrefix),
+		[]sdk.Attribute{
+			{Key: AttributeKeyContractAddress, Value: addr.String()},
+			{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"},
+			{Key: "key3", Value: "value3"},
+		}...,
+	), sdk.NewEvent(
+		fmt.Sprintf("%s-type2", EventTypeWasmPrefix),
+		[]sdk.Attribute{
+			{Key: AttributeKeyContractAddress, Value: addr.String()},
+			{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"},
+			{Key: "key3", Value: "value3"},
+		}...,
+	)}, events)
+}
+
 func TestBuildEvent(t *testing.T) {
 	_, _, addr := keyPubAddr()
 


### PR DESCRIPTION
## Summary of changes

close #528

We try dereferencing the event, so before building the event we have to check the length.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
