### PR TITLE
fix to use amino multisig pubkey at migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.5.4]
+
+### Bug Fixes
+- [\#560](https://github.com/terra-money/core/pull/560) Fix migration bug of multisig pubkey which was in v040 auth module migration.
+
 ## [v0.5.3]
 
 ### Improvement

--- a/custom/auth/legacy/v039/types.go
+++ b/custom/auth/legacy/v039/types.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -149,13 +148,13 @@ func (lgva LazyGradedVestingAccount) MarshalJSON() ([]byte, error) {
 		VestingSchedules: lgva.VestingSchedules,
 	}
 
-	return legacy.Cdc.MarshalJSON(alias)
+	return internalCdc.MarshalJSON(alias)
 }
 
 // UnmarshalJSON unmarshals raw JSON bytes into a LazyGradedVestingAccount.
 func (lgva *LazyGradedVestingAccount) UnmarshalJSON(bz []byte) error {
 	var alias vestingAccountJSON
-	if err := legacy.Cdc.UnmarshalJSON(bz, &alias); err != nil {
+	if err := internalCdc.UnmarshalJSON(bz, &alias); err != nil {
 		return err
 	}
 
@@ -190,7 +189,7 @@ func (*LegacyAminoPubKey) ProtoMessage() {}
 func (*LegacyAminoPubKey) Reset() {}
 
 // String no-lint
-func (*LegacyAminoPubKey) String() string { return "TODO" }
+func (*LegacyAminoPubKey) String() string { return "not implemented" }
 
 // Type no-lint
 func (*LegacyAminoPubKey) Type() string { return "PubKeyMultisigThreshold" }
@@ -198,6 +197,13 @@ func (*LegacyAminoPubKey) Type() string { return "PubKeyMultisigThreshold" }
 // VerifySignature no-lint
 func (*LegacyAminoPubKey) VerifySignature(msg []byte, sig []byte) bool {
 	panic("not implemented")
+}
+
+var internalCdc *codec.LegacyAmino
+
+func init() {
+	internalCdc = codec.NewLegacyAmino()
+	RegisterLegacyAminoCodec(internalCdc)
 }
 
 // RegisterLegacyAminoCodec nonlint

--- a/custom/auth/legacy/v040/migrate.go
+++ b/custom/auth/legacy/v040/migrate.go
@@ -2,7 +2,7 @@ package v040
 
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
+	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -25,7 +25,7 @@ func convertBaseAccount(old *v039auth.BaseAccount) *v040auth.BaseAccount {
 	if old.PubKey != nil {
 		var pk cryptotypes.PubKey
 		if mpk, ok := old.PubKey.(*v039authcustom.LegacyAminoPubKey); ok {
-			pk = multisig.NewLegacyAminoPubKey(int(mpk.Threshold.Int64()), mpk.PubKeys)
+			pk = kmultisig.NewLegacyAminoPubKey(int(mpk.Threshold.Int64()), mpk.PubKeys)
 		} else {
 			pk = old.PubKey
 		}

--- a/custom/auth/legacy/v040/migrate_test.go
+++ b/custom/auth/legacy/v040/migrate_test.go
@@ -1,0 +1,31 @@
+package v040
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v039authcustom "github.com/terra-money/core/custom/auth/legacy/v039"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	v038auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v038"
+)
+
+func TestMultisigPubkeyMigration(t *testing.T) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount("terra", "terrapub")
+
+	v04Codec := codec.NewLegacyAmino()
+	v039authcustom.RegisterLegacyAminoCodec(v04Codec)
+	jsonAccount := `{"type":"core/LazyGradedVestingAccount","value":{"address":"terra1dp0taj85ruc299rkdvzp4z5pfg6z6swaed74e6","coins":[],"public_key":{"type":"tendermint/PubKeyMultisigThreshold","value":{"threshold":"2","pubkeys":[{"type":"tendermint/PubKeySecp256k1","value":"AyETa9Y9ihObzeRPWMP0MBAa0Mqune3I+5KonOCPTtkv"},{"type":"tendermint/PubKeySecp256k1","value":"AzzLltyI4MzxLpcmS1vfpXJeAk/sgS1eVYmvXgFpGRtg"},{"type":"tendermint/PubKeySecp256k1","value":"AnZjvWmye3JPEL95xRcGeFRf4o8pHDK0dkZjf6B9D4FA"}]}},"account_number":"317776","sequence":"61","original_vesting":[{"denom":"usdr","amount":"1000000000000000"}],"delegated_free":[{"denom":"uluna","amount":"57620630000008"}],"delegated_vesting":[],"end_time":"0","vesting_schedules":[{"denom":"usdr","schedules":[{"start_time":"1556085600","end_time":"1558677600","ratio":"0.100000000000000000"},{"start_time":"1587708000","end_time":"1590300000","ratio":"0.100000000000000000"},{"start_time":"1619244000","end_time":"1621836000","ratio":"0.100000000000000000"},{"start_time":"1650780000","end_time":"1653372000","ratio":"0.100000000000000000"},{"start_time":"1682316000","end_time":"1684908000","ratio":"0.100000000000000000"},{"start_time":"1713938400","end_time":"1716530400","ratio":"0.100000000000000000"},{"start_time":"1745474400","end_time":"1748066400","ratio":"0.100000000000000000"},{"start_time":"1777010400","end_time":"1779602400","ratio":"0.100000000000000000"},{"start_time":"1808546400","end_time":"1811138400","ratio":"0.100000000000000000"},{"start_time":"1840168800","end_time":"1842760800","ratio":"0.100000000000000000"}]}]}}`
+
+	var oldAccount v038auth.GenesisAccount
+	v04Codec.MustUnmarshalJSON([]byte(jsonAccount), &oldAccount)
+
+	account := convertBaseVestingAccount(oldAccount.(*v039authcustom.LazyGradedVestingAccount).BaseVestingAccount)
+
+	pk, ok := account.GetPubKey().(multisig.PubKey)
+	require.True(t, ok)
+	require.Equal(t, 3, len(pk.GetPubKeys()))
+}

--- a/custom/auth/legacy/v040/store.go
+++ b/custom/auth/legacy/v040/store.go
@@ -1,0 +1,27 @@
+// Package v040 creates in-place store migrations for fixing
+// multisig pubkey migration problem
+// ref: https://github.com/terra-money/core/issues/562
+package v040
+
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// Set MultiSig account PubKey as nil
+func migrateMultiSigAccount(account types.AccountI) (types.AccountI, error) {
+	_, ok := account.GetPubKey().(multisig.PubKey)
+	if !ok {
+		return nil, nil
+	}
+
+	_ = account.SetPubKey(nil)
+	return account.(types.AccountI), nil
+}
+
+// MigrateAccount migrates multisig account's PubKey as nil to restore mistakenly set PubKey
+// References: https://github.com/terra-money/core/issues/562
+//
+func MigrateAccount(account types.AccountI) (types.AccountI, error) {
+	return migrateMultiSigAccount(account)
+}


### PR DESCRIPTION
## Summary of changes

fix #562 

Use custom LegacyAminoPubkey for multisig account pub key.

To softly upgrade bombay-11 network, we add upgrade handler for pain name `multisig-pubkey-migration`.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
