### PR TITLE
[Feature] legacy tx encode support

### DIFF
--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -1098,10 +1098,10 @@ paths:
       deprecated: true
       tags:
         - Transactions
-      summary: Encode a transaction to the Amino wire format
+      summary: Encode a legacy transaction to the Proto wire format
       description: >-
-        Encode a transaction (signed or not) from JSON to base64-encoded Amino
-        serialized bytes
+        Encode a legacy transaction (signed or not) from JSON to base64-encoded
+        Proto serialized bytes
       consumes:
         - application/json
       produces:
@@ -1161,6 +1161,17 @@ paths:
                       sequence:
                         type: string
                         example: '0'
+              sequences:
+                required: false
+                type: array
+                items:
+                  type: string
+                  example: '1'
+              fee_granter:
+                type: string
+                description: bech32 encoded address
+                example: terra1wg2mlrxdmnnkkykgqg4znky86nyrtc45q336yv
+                required: false
       responses:
         '200':
           description: The tx was successfully decoded and re-encoded
@@ -1169,7 +1180,7 @@ paths:
             properties:
               tx:
                 type: string
-                example: The base64-encoded Amino-serialized bytes for the tx
+                example: The base64-encoded Proto-serialized bytes for the tx
         '400':
           description: The tx was malformed
         '500':

--- a/client/docs/swagger_legacy.yaml
+++ b/client/docs/swagger_legacy.yaml
@@ -340,8 +340,8 @@ paths:
       deprecated: true
       tags:
         - Transactions
-      summary: Encode a transaction to the Amino wire format
-      description: Encode a transaction (signed or not) from JSON to base64-encoded Amino serialized bytes
+      summary: Encode a legacy transaction to the Proto wire format
+      description: Encode a legacy transaction (signed or not) from JSON to base64-encoded Proto serialized bytes
       consumes:
         - application/json
       produces:
@@ -356,6 +356,15 @@ paths:
             properties:
               tx:
                 $ref: "#/definitions/StdTx"
+              sequences:
+                required: false
+                type: array
+                items:
+                  type: string
+                  example: "1"
+              fee_granter:
+                required: false
+                $ref: "#/definitions/Address"
       responses:
         200:
           description: The tx was successfully decoded and re-encoded
@@ -364,7 +373,7 @@ paths:
             properties:
               tx:
                 type: string
-                example: The base64-encoded Amino-serialized bytes for the tx
+                example: The base64-encoded Proto-serialized bytes for the tx
         400:
           description: The tx was malformed
         500:

--- a/custom/auth/client/rest/broadcast.go
+++ b/custom/auth/client/rest/broadcast.go
@@ -102,7 +102,7 @@ func BroadcastTxRequest(clientCtx client.Context) http.HandlerFunc {
 			return
 		}
 
-		// compute signature bytes
+		// compute tx bytes
 		txBytes, err := clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
 		if rest.CheckInternalServerError(w, err) {
 			return

--- a/custom/auth/client/rest/encode.go
+++ b/custom/auth/client/rest/encode.go
@@ -1,0 +1,112 @@
+package rest
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/cosmos/cosmos-sdk/x/auth/legacy/legacytx"
+)
+
+// EncodeReq defines a tx encode request.
+type EncodeReq struct {
+	Tx         legacytx.StdTx `json:"tx" yaml:"tx"`
+	Sequences  []uint64       `json:"sequences" yaml:"sequences"`
+	FeeGranter string         `json:"fee_granter" yaml:"fee_granter"`
+}
+
+// EncodeResq defines a tx encode response.
+type EncodeResq struct {
+	Tx []byte `json:"tx" yaml:"tx"`
+}
+
+var _ codectypes.UnpackInterfacesMessage = EncodeReq{}
+
+// UnpackInterfaces implements the UnpackInterfacesMessage interface.
+func (m EncodeReq) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	return m.Tx.UnpackInterfaces(unpacker)
+}
+
+// EncodeTxRequest implements a tx encode handler that is responsible
+// for encoding a legacy tx into new format tx bytes.
+func EncodeTxRequest(clientCtx client.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req EncodeReq
+
+		body, err := ioutil.ReadAll(r.Body)
+		if rest.CheckBadRequestError(w, err) {
+			return
+		}
+
+		// NOTE: amino is used intentionally here, don't migrate it!
+		err = clientCtx.LegacyAmino.UnmarshalJSON(body, &req)
+		if err != nil {
+			if rest.CheckBadRequestError(w, err) {
+				return
+			}
+		}
+
+		txBuilder := clientCtx.TxConfig.NewTxBuilder()
+		txBuilder.SetFeeAmount(req.Tx.GetFee())
+		txBuilder.SetGasLimit(req.Tx.GetGas())
+		txBuilder.SetMemo(req.Tx.GetMemo())
+		if err := txBuilder.SetMsgs(req.Tx.GetMsgs()...); rest.CheckBadRequestError(w, err) {
+			return
+		}
+
+		txBuilder.SetTimeoutHeight(req.Tx.GetTimeoutHeight())
+		if req.FeeGranter != "" {
+			addr, err := sdk.AccAddressFromBech32(req.FeeGranter)
+			if rest.CheckBadRequestError(w, err) {
+				return
+			}
+
+			txBuilder.SetFeeGranter(addr)
+		}
+
+		signatures, err := req.Tx.GetSignaturesV2()
+		if rest.CheckBadRequestError(w, err) {
+			return
+		}
+
+		// if sequence is not given, try fetch from the chain
+		if len(req.Sequences) == 0 {
+			for _, sig := range signatures {
+				_, seq, err := clientCtx.AccountRetriever.GetAccountNumberSequence(clientCtx, sdk.AccAddress(sig.PubKey.Address().Bytes()))
+				if rest.CheckBadRequestError(w, err) {
+					return
+				}
+				req.Sequences = append(req.Sequences, seq)
+			}
+		}
+
+		// check the sequence nubmer is equal with the signature nubmer
+		if len(signatures) != len(req.Sequences) {
+			rest.CheckBadRequestError(w, errors.New("Must provide each signers's sequence number"))
+			return
+		}
+
+		// fill sequence number to new signature
+		for i, seq := range req.Sequences {
+			signatures[i].Sequence = seq
+		}
+
+		if err := txBuilder.SetSignatures(signatures...); rest.CheckBadRequestError(w, err) {
+			return
+		}
+
+		// compute tx bytes
+		txBytes, err := clientCtx.TxConfig.TxEncoder()(txBuilder.GetTx())
+		if rest.CheckInternalServerError(w, err) {
+			return
+		}
+
+		rest.PostProcessResponseBare(w, clientCtx, EncodeResq{
+			Tx: txBytes,
+		})
+	}
+}

--- a/custom/auth/client/rest/rest.go
+++ b/custom/auth/client/rest/rest.go
@@ -11,5 +11,6 @@ import (
 func RegisterTxRoutes(clientCtx client.Context, rtr *mux.Router) {
 	r := clientrest.WithHTTPDeprecationHeaders(rtr)
 	r.HandleFunc("/txs/estimate_fee", EstimateTxFeeRequestHandlerFn(clientCtx)).Methods("POST")
+	r.HandleFunc("/txs/encode", EncodeTxRequest(clientCtx)).Methods("POST")
 	r.HandleFunc("/txs", BroadcastTxRequest(clientCtx)).Methods("POST")
 }


### PR DESCRIPTION
## Summary of changes

implement `/txs/encode` endpoint for Backward compatibility to convert a legacy StdTx into new Proto style txbytes.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
