### PR TITLE
Update broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ Full-node software implementing the Terra protocol<br/><br/>
   <a href="https://docs.terra.money/"><strong>Explore the Docs »</strong></a>
   <br />
   <br/>
-  <a href="https://docs.terra.money/dev">Dev Guide</a>
+  <a href="https://docs.terra.money/Reference/">Terra Core reference</a>
   ·
   <a href="https://pkg.go.dev/github.com/terra-money/core?tab=subdirectories">Go API</a>
   ·
-  <a href="https://swagger.terra.money/">REST API</a>
+  <a href="https://lcd.terra.dev/swagger-ui/">Rest API</a>
   ·
-  <a href="https://docs.terra.money/#sdks-for-developers">SDKs</a>
+  <a href="https://terra-money.github.io/terra-sdk-python/">Python SDK</a>
+  ·
+  <a href="https://terra-money.github.io/terra.js/">Terra.js</a>
   ·
   <a href="https://finder.terra.money/">Finder</a>
   ·


### PR DESCRIPTION
## Summary of changes

The links to the new docs site were broken due to restructuring. I updated broken links in Readme to reflect docs site change. Update to: rest API, reference docs. Links added for Python SDK and Terra.js

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
