### PR TITLE
[Feature] add ibc ante to prevent duplicate packet from relayer

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -551,13 +551,14 @@ func NewTerraApp(
 
 	anteHandler, err := customante.NewAnteHandler(
 		customante.HandlerOptions{
-			AccountKeeper:   app.AccountKeeper,
-			BankKeeper:      app.BankKeeper,
-			FeegrantKeeper:  app.FeeGrantKeeper,
-			OracleKeeper:    app.OracleKeeper,
-			TreasuryKeeper:  app.TreasuryKeeper,
-			SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
-			SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
+			AccountKeeper:    app.AccountKeeper,
+			BankKeeper:       app.BankKeeper,
+			FeegrantKeeper:   app.FeeGrantKeeper,
+			OracleKeeper:     app.OracleKeeper,
+			TreasuryKeeper:   app.TreasuryKeeper,
+			SigGasConsumer:   ante.DefaultSigVerificationGasConsumer,
+			SignModeHandler:  encodingConfig.TxConfig.SignModeHandler(),
+			IBCChannelKeeper: app.IBCKeeper.ChannelKeeper,
 		},
 	)
 	if err != nil {

--- a/custom/auth/ante/ante.go
+++ b/custom/auth/ante/ante.go
@@ -1,6 +1,9 @@
 package ante
 
 import (
+	channelkeeper "github.com/cosmos/ibc-go/modules/core/04-channel/keeper"
+	ibcante "github.com/cosmos/ibc-go/modules/core/ante"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -10,13 +13,14 @@ import (
 
 // HandlerOptions are the options required for constructing a default SDK AnteHandler.
 type HandlerOptions struct {
-	AccountKeeper   cosmosante.AccountKeeper
-	BankKeeper      types.BankKeeper
-	FeegrantKeeper  cosmosante.FeegrantKeeper
-	OracleKeeper    OracleKeeper
-	TreasuryKeeper  TreasuryKeeper
-	SignModeHandler signing.SignModeHandler
-	SigGasConsumer  cosmosante.SignatureVerificationGasConsumer
+	AccountKeeper    cosmosante.AccountKeeper
+	BankKeeper       types.BankKeeper
+	FeegrantKeeper   cosmosante.FeegrantKeeper
+	OracleKeeper     OracleKeeper
+	TreasuryKeeper   TreasuryKeeper
+	SignModeHandler  signing.SignModeHandler
+	SigGasConsumer   cosmosante.SignatureVerificationGasConsumer
+	IBCChannelKeeper channelkeeper.Keeper
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -63,5 +67,6 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		cosmosante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
 		cosmosante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		cosmosante.NewIncrementSequenceDecorator(options.AccountKeeper),
+		ibcante.NewAnteDecorator(options.IBCChannelKeeper),
 	), nil
 }


### PR DESCRIPTION
## Summary of changes

Append IBC ante decorator to reject transactions that only contain redundant packet messages. This will prevent relayers from wasting fees by submitting messages for packets that have already been processed by previous relayer(s). The Antedecorator is only applied on CheckTx and RecheckTx and is therefore optional for each node. 

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
