### PR TITLE
[Hotfix] block deep recursive query

### DIFF
--- a/x/wasm/keeper/contract.go
+++ b/x/wasm/keeper/contract.go
@@ -437,6 +437,12 @@ func (k Keeper) queryToContract(ctx sdk.Context, contractAddress sdk.AccAddress,
 		wasmVM = wasmVMs[0]
 	}
 
+	// assert max depth to prevent stack overflow
+	if err := wasmVM.IncreaseQueryDepth(); err != nil {
+		return nil, err
+	}
+	defer wasmVM.DecreaseQueryDepth()
+
 	queryResult, gasUsed, err := wasmVM.Query(
 		codeInfo.CodeHash,
 		env,

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -70,16 +70,17 @@ func NewKeeper(
 		wasmConfig.WriteVMMemoryCacheSize = config.DefaultWriteVMMemoryCacheSize
 	}
 
-	writeWasmVM, err := wasmvm.NewVM(
+	var writeWasmVM types.WasmerEngine
+	if vm, err := wasmvm.NewVM(
 		filepath.Join(homePath, config.DBDir),
 		supportedFeatures,
 		types.ContractMemoryLimit,
 		wasmConfig.ContractDebugMode,
 		wasmConfig.WriteVMMemoryCacheSize,
-	)
-
-	if err != nil {
+	); err != nil {
 		panic(err)
+	} else {
+		writeWasmVM = types.NewWasmerEngineWithQueryDepth(vm)
 	}
 
 	// prevent zero read vm
@@ -95,16 +96,16 @@ func NewKeeper(
 	numReadVms := wasmConfig.NumReadVMs
 	wasmReadVMPool := make([]types.WasmerEngine, numReadVms)
 	for i := uint32(0); i < numReadVms; i++ {
-		wasmReadVMPool[i], err = wasmvm.NewVM(
+		if vm, err := wasmvm.NewVM(
 			filepath.Join(homePath, config.DBDir),
 			supportedFeatures,
 			types.ContractMemoryLimit,
 			wasmConfig.ContractDebugMode,
 			wasmConfig.ReadVMMemoryCacheSize,
-		)
-
-		if err != nil {
+		); err != nil {
 			panic(err)
+		} else {
+			wasmReadVMPool[i] = types.NewWasmerEngineWithQueryDepth(vm)
 		}
 	}
 

--- a/x/wasm/keeper/recursive_test.go
+++ b/x/wasm/keeper/recursive_test.go
@@ -342,3 +342,20 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 		})
 	}
 }
+
+func TestLimitRecursiveQueryDepth(t *testing.T) {
+
+	contractAddr, _, ctx, keeper, _ := initRecurseContract(t)
+	msg := buildQuery(t, Recurse{
+		Depth: types.ContractMaxQueryDepth - 1, // need to exclude first query
+	})
+
+	_, err := keeper.queryToContract(ctx, contractAddr, msg)
+	require.NoError(t, err)
+
+	msg = buildQuery(t, Recurse{
+		Depth: types.ContractMaxQueryDepth,
+	})
+	_, err = keeper.queryToContract(ctx, contractAddr, msg)
+	require.Error(t, err)
+}

--- a/x/wasm/keeper/recursive_test.go
+++ b/x/wasm/keeper/recursive_test.go
@@ -347,7 +347,7 @@ func TestLimitRecursiveQueryDepth(t *testing.T) {
 
 	contractAddr, _, ctx, keeper, _ := initRecurseContract(t)
 	msg := buildQuery(t, Recurse{
-		Depth: types.ContractMaxQueryDepth - 1, // need to exclude first query
+		Depth: types.ContractMaxQueryDepth - 1, // need to include first query
 	})
 
 	_, err := keeper.queryToContract(ctx, contractAddr, msg)

--- a/x/wasm/types/errors.go
+++ b/x/wasm/types/errors.go
@@ -23,4 +23,5 @@ var (
 	ErrExceedMaxContractMsgSize  = sdkerrors.Register(ModuleName, 16, "exceeds max contract msg size limit")
 	ErrExceedMaxContractDataSize = sdkerrors.Register(ModuleName, 17, "exceeds max contract data size limit")
 	ErrReplyFailed               = sdkerrors.Register(ModuleName, 18, "reply wasm contract failed")
+	ErrExceedMaxQueryDepth       = sdkerrors.Register(ModuleName, 19, "exceed max query depth")
 )

--- a/x/wasm/types/wasmer_engine.go
+++ b/x/wasm/types/wasmer_engine.go
@@ -5,7 +5,8 @@ import (
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 )
 
-const maxQueryDepth = 20
+// ContractMaxQueryDepth maximum recursive query depth allowed
+const ContractMaxQueryDepth = 20
 
 var _ WasmerEngine = &WasmerEngineWithQueryDepth{}
 
@@ -25,7 +26,7 @@ func NewWasmerEngineWithQueryDepth(wasmVM *wasmvm.VM) *WasmerEngineWithQueryDept
 // IncreaseQueryDepth increase execution depth by 1 and check whether
 // the depth exceeds max one or not
 func (wasmer *WasmerEngineWithQueryDepth) IncreaseQueryDepth() error {
-	if wasmer.QueryDepth >= maxQueryDepth {
+	if wasmer.QueryDepth >= ContractMaxQueryDepth {
 		return ErrExceedMaxQueryDepth
 	}
 


### PR DESCRIPTION
## Summary of changes

Reject tx which is executing  deep recursive query to prevent node crash.

* Set max query depth to `20`

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
