### PR TITLE
[Bugfix] fix to use single wasmvm during recursive external query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.5.9]
+
+### Bug Fixes
+- [\#588](https://github.com/terra-money/core/pull/588) - fix wasm external querier to use single wasmvm with context value
+
 ## [v0.5.8]
 
 ### Bug Fixes

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -35,7 +35,7 @@ type Keeper struct {
 	queryRouter   types.GRPCQueryRouter
 
 	wasmVM              types.WasmerEngine
-	wasmReadVMPool      []types.WasmerEngine
+	wasmReadVMPool      *[]types.WasmerEngine
 	wasmReadVMSemaphore *semaphore.Weighted
 	wasmReadVMMutex     *sync.Mutex
 
@@ -114,7 +114,7 @@ func NewKeeper(
 		cdc:                 cdc,
 		paramSpace:          paramspace,
 		wasmVM:              writeWasmVM,
-		wasmReadVMPool:      wasmReadVMPool,
+		wasmReadVMPool:      &wasmReadVMPool,
 		wasmReadVMSemaphore: semaphore.NewWeighted(int64(numReadVms)),
 		wasmReadVMMutex:     &sync.Mutex{},
 		accountKeeper:       accountKeeper,

--- a/x/wasm/keeper/legacy_querier.go
+++ b/x/wasm/keeper/legacy_querier.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 
@@ -147,7 +148,9 @@ func queryContractStore(ctx sdk.Context, req abci.RequestQuery, k Keeper, legacy
 		}
 	}()
 
-	bz, err = k.queryToContract(ctx, params.ContractAddress, params.Msg, wasmVM)
+	// store query wasmvm in the context
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), types.QueryWasmVMContextKey, wasmVM))
+	bz, err = k.queryToContract(ctx, params.ContractAddress, params.Msg)
 
 	return
 }

--- a/x/wasm/keeper/pool.go
+++ b/x/wasm/keeper/pool.go
@@ -6,8 +6,6 @@ import (
 	"github.com/terra-money/core/x/wasm/types"
 )
 
-var n = 0
-
 func (k Keeper) acquireWasmVM(ctx context.Context) (types.WasmerEngine, error) {
 	err := k.wasmReadVMSemaphore.Acquire(ctx, 1)
 	if err != nil {
@@ -15,8 +13,8 @@ func (k Keeper) acquireWasmVM(ctx context.Context) (types.WasmerEngine, error) {
 	}
 
 	k.wasmReadVMMutex.Lock()
-	wasmVM := k.wasmReadVMPool[0]
-	k.wasmReadVMPool = k.wasmReadVMPool[1:]
+	wasmVM := (*k.wasmReadVMPool)[0]
+	*k.wasmReadVMPool = (*k.wasmReadVMPool)[1:]
 	k.wasmReadVMMutex.Unlock()
 
 	return wasmVM, nil
@@ -24,7 +22,7 @@ func (k Keeper) acquireWasmVM(ctx context.Context) (types.WasmerEngine, error) {
 
 func (k Keeper) releaseWasmVM(wasmVM types.WasmerEngine) {
 	k.wasmReadVMMutex.Lock()
-	k.wasmReadVMPool = append(k.wasmReadVMPool, wasmVM)
+	*k.wasmReadVMPool = append(*k.wasmReadVMPool, wasmVM)
 	k.wasmReadVMMutex.Unlock()
 
 	k.wasmReadVMSemaphore.Release(1)

--- a/x/wasm/keeper/querier.go
+++ b/x/wasm/keeper/querier.go
@@ -120,8 +120,9 @@ func (q querier) ContractStore(c context.Context, req *types.QueryContractStoreR
 		}
 	}()
 
-	var bz []byte
-	bz, err = q.queryToContract(ctx, contractAddr, req.QueryMsg, wasmVM)
+	// store query wasmvm in the context
+	ctx = ctx.WithContext(context.WithValue(ctx.Context(), types.QueryWasmVMContextKey, wasmVM))
+	bz, err := q.queryToContract(ctx, contractAddr, req.QueryMsg)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/x/wasm/types/keys.go
+++ b/x/wasm/types/keys.go
@@ -20,6 +20,9 @@ const (
 
 	// RouterKey is the msg router key for the wasm module
 	RouterKey = ModuleName
+
+	// QueryWasmVMContextKey is the context key to store wasmvm in query context
+	QueryWasmVMContextKey = "wasmvm"
 )
 
 // Keys for wasm store


### PR DESCRIPTION
## Summary of changes
close #587 

Also previously, only single wasmvm was used because wasm keeper did not maintain reference of ReadVMPool.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
