### PR TITLE
Revert "[Feature] use jemalloc as wasm global memory allocator"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Improvements
+- [\#593](https://github.com/terra-money/core/pull/588) revert jemalloc integration from wasmvm & add troubleshoot section to docs
+
 ## [v0.5.9]
 
 ### Bug Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN apk add git
 WORKDIR /code
 COPY . /code/
 
-# See https://github.com/terra-money/wasmvm/releases
-ADD https://github.com/terra-money/wasmvm/releases/download/v0.16.1/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
-RUN sha256sum /lib/libwasmvm_muslc.a | grep 7a44ca40fbd1e4b27325fa5053c4699b2b7a5dcb043a8763792acfa8f2adae70
+# See https://github.com/CosmWasm/wasmvm/releases
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v0.16.1/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+RUN sha256sum /lib/libwasmvm_muslc.a | grep 0e62296b9f24cf3a05f8513f99cee536c7087079855ea6ffb4f89b35eccdaa66
 
 # force it to use static lib (from above) not standard libgo_cosmwasm.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc make build

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/CosmWasm/wasmvm => github.com/terra-money/wasmvm v0.16.1
 	github.com/cosmos/ledger-cosmos-go => github.com/terra-money/ledger-terra-go v0.11.2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
+github.com/CosmWasm/wasmvm v0.16.1 h1:o14Y9xnxaLaLnYiFG9rIna2ZtmB/F8BAIOLboVzXguQ=
+github.com/CosmWasm/wasmvm v0.16.1/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
@@ -1010,8 +1012,6 @@ github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XX
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/terra-money/ledger-terra-go v0.11.2 h1:BVXZl+OhJOri6vFNjjVaTabRLApw9MuG7mxWL4V718c=
 github.com/terra-money/ledger-terra-go v0.11.2/go.mod h1:ClJ2XMj1ptcnONzKH+GhVPi7Y8pXIT+UzJ0TNt0tfZE=
-github.com/terra-money/wasmvm v0.16.1 h1:wa+qhKUtVaipwscwsGiho3zVruh0cCxHmprmfbGBh9w=
-github.com/terra-money/wasmvm v0.16.1/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
 github.com/tetafro/godot v1.4.9/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=

--- a/shared.Dockerfile
+++ b/shared.Dockerfile
@@ -11,7 +11,7 @@ COPY . /code/
 
 RUN LEDGER_ENABLED=false make build
 
-RUN cp /go/pkg/mod/github.com/terra-money/wasmvm@v*/api/libwasmvm.so /lib/libwasmvm.so
+RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/api/libwasmvm.so /lib/libwasmvm.so
 
 FROM ubuntu:20.04
 


### PR DESCRIPTION
Reverts terra-money/core#586
close #592 

Instead adopting jemalloc only for wasmvm, we need to replace whole memory allocator of terrad process.

for that,

1. Install `jemalloc`.

```bash
JEMALLOC_VERSION=5.2.1
wget https://github.com/jemalloc/jemalloc/releases/download/$JEMALLOC_VERSION/jemalloc-$JEMALLOC_VERSION.tar.bz2 
tar -xf ./jemalloc-$JEMALLOC_VERSION.tar.bz2 
cd jemalloc-$JEMALLOC_VERSION

# for the node with high query rate or wasm cache size, recommend below config
# ./configure --with-malloc-conf=background_thread:true,dirty_decay_ms:5000,muzzy_decay_ms:5000
./configure --with-malloc-conf=background_thread:true,metadata_thp:auto,dirty_decay_ms:30000,muzzy_decay_ms:30000
make
sudo make install
```

2. Restart the process with `LD_PRELOAD=/usr/local/lib/libjemalloc.so terrad start`.

  If you are using `systemd` or another process manager to launch `terrad`, you might need to configure them. The following  sample `systemd` file fixes the problem:

  ```systemd
  # /etc/systemd/system/terrad.service
  [Unit]
  Description=Terra Columbus Node
  After=network.target

  [Service]
  Type=simple
  User=ubuntu
  WorkingDirectory=/home/ubuntu
  ExecStart=/home/ubuntu/go/bin/terrad start
  Restart=on-failure
  RestartSec=3
  LimitNOFILE=4096
  Environment="LD_PRELOAD=/usr/local/lib/libjemalloc.so"

  [Install]
  WantedBy=multi-user.target
  ```
 