### PR TITLE
[Bugfix] Bump wasmvm to v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.5.11
 
 ### Bug Fixes
-- [\#602](https://github.com/terra-money/core/pull/602) bump CosmWasm/wasmvm to v0.16.2 to fix cache position error
+- [\#603](https://github.com/terra-money/core/pull/603) bump CosmWasm/wasmvm to v0.16.2 to fix cache position error
 
 ## v0.5.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.5.11
+
+### Bug Fixes
+- [\#602](https://github.com/terra-money/core/pull/602) bump CosmWasm/wasmvm to v0.16.2 to fix cache position error
+
 ## v0.5.10
 
 ### Improvements

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ go 1.16
 module github.com/terra-money/core
 
 require (
-	github.com/CosmWasm/wasmvm v0.16.1
+	github.com/CosmWasm/wasmvm v0.16.2
 	github.com/cosmos/cosmos-sdk v0.44.2
 	github.com/cosmos/ibc-go v1.1.0
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v0.16.1 h1:o14Y9xnxaLaLnYiFG9rIna2ZtmB/F8BAIOLboVzXguQ=
-github.com/CosmWasm/wasmvm v0.16.1/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
+github.com/CosmWasm/wasmvm v0.16.2 h1:grOU0p5Fd/GN4j8ZvQ7bdgmNStk6FFqFp5NSPvrkO1s=
+github.com/CosmWasm/wasmvm v0.16.2/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=


### PR DESCRIPTION
## Summary of changes

close #599 

This update is security update of wasmvm [ref](https://gist.github.com/webmaster128/99f48b6e1de51453935a6f32da4ad3ee).

The problem monitored only happens in the nodes which are receiving wasm queries, so the query nodes are highly recommended to update ASAP to avoid node crash.

## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [x] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [x] Added appropriate labels to PR
- [x] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [x] Confirm added tests are consistent with the intended behavior of changes
- [x] Ensure all tests pass
