### PR TITLE
Update Docker images to use the `--db_dir` flag. 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN if [ "$chainid" = "columbus-5" ] ; then wget -O ~/.terra/config/addrbook.jso
 RUN if [ "$chainid" = "bombay-12" ] ; then wget -O ~/.terra/config/genesis.json https://raw.githubusercontent.com/terra-money/testnet/master/bombay-12/genesis.json; fi
 RUN if [ "$chainid" = "bombay-12" ] ; then wget -O ~/.terra/config/addrbook.json https://raw.githubusercontent.com/terra-money/testnet/master/bombay-12/addrbook.json; fi
 
-RUN apk update && apk add wget lz4 aria2 curl jq gawk
+RUN apk update && apk add wget lz4 aria2 curl jq gawk coreutils
 
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,31 +7,37 @@
 Standard options with LCD enabled: 
 
 ```
-docker run -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terra-money/core-node:v0.5.9-oracle
+docker run -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle
 ```
 
 LCD disabled: 
 
 ```
-docker run -e ENABLE_LCD=false -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terra-money/core-node:v0.5.9-oracle
+docker run -e ENABLE_LCD=false -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle
 ```
 
 Custom gas fees: 
 
 ```
-docker run -e MINIMUM_GAS_PRICES="0.01133uluna,0.15uusd,0.104938usdr,169.77ukrw,428.571umnt,0.125ueur,0.98ucny,16.37ujpy,0.11ugbp,10.88uinr,0.19ucad,0.14uchf,0.19uaud,0.2usgd,4.62uthb,1.25usek,1.25unok,0.9udkk,2180.0uidr,7.6uphp,1.17uhkd" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terra-money/core-node:v0.5.9-oracle
+docker run -e MINIMUM_GAS_PRICES="0.01133uluna,0.15uusd,0.104938usdr,169.77ukrw,428.571umnt,0.125ueur,0.98ucny,16.37ujpy,0.11ugbp,10.88uinr,0.19ucad,0.14uchf,0.19uaud,0.2usgd,4.62uthb,1.25usek,1.25unok,0.9udkk,2180.0uidr,7.6uphp,1.17uhkd" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle
 ```
 
-Custom snapshot name (for when new snapshots come out):
+Starting the sync from a snapshot:
 
 ```
-docker run -e SNAPSHOT_NAME="columbus-5-pruned.20211022.0410.tar.lz4" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terra-money/core-node:v0.5.9-oracle
+docker run -e SNAPSHOT_NAME="columbus-5-pruned.20211022.0410.tar.lz4" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle
 ```
 
-Custom snapshot URL
+Custom snapshot URL:
 
 ```
-docker run -e SNAPSHOT_BASE_URL="https://get.quicksync.io" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terra-money/core-node:v0.5.9-oracle
+docker run -e SNAPSHOT_BASE_URL="https://get.quicksync.io" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle
+```
+
+Starting a bombay node: 
+
+```
+docker run -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle-testnet
 ```
 
 **Note:** We recommend copying a snapshot to S3 or another file store and using the above options to point the container to your snapshot. The default snapshot name included will be obsolete and removed in a matter of days.
@@ -39,5 +45,5 @@ docker run -e SNAPSHOT_BASE_URL="https://get.quicksync.io" -it -p 1317:1317 -p 2
 ## Building the Docker images
 
 ```
-./build_all.sh v0.5.9-oracle
+./build_all.sh v0.5.11-oracle
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,19 +28,21 @@ Starting the sync from a snapshot:
 docker run -e SNAPSHOT_NAME="columbus-5-pruned.20211022.0410.tar.lz4" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle
 ```
 
+You can find the latest snapshots [here](https://quicksync.io/networks/terra.html).
+
 Custom snapshot URL:
 
 ```
 docker run -e SNAPSHOT_BASE_URL="https://get.quicksync.io" -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle
 ```
 
+**Note:** We recommend copying a snapshot to S3 or another file store and using the above options to point the container to your snapshot. The default snapshot name included will be obsolete and removed in a matter of days.
+
 Starting a bombay node: 
 
 ```
 docker run -it -p 1317:1317 -p 26657:26657 -p 26656:26656 terramoney/core-node:v0.5.11-oracle-testnet
 ```
-
-**Note:** We recommend copying a snapshot to S3 or another file store and using the above options to point the container to your snapshot. The default snapshot name included will be obsolete and removed in a matter of days.
 
 ## Building the Docker images
 

--- a/docker/build_all.sh
+++ b/docker/build_all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="${1:-v0.5.9-oracle}"
+VERSION="${1:-v0.5.11-oracle}"
 
 pushd .. 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,19 +32,14 @@ if [ "$CHAINID" = "columbus-5" ] && [[ ! -z "$SNAPSHOT_NAME" ]] ; then
       mkdir -p $DATADIR
       cd $DATADIR
       FILENAME="$SNAPSHOT_NAME"
-      aria2c -x5 $SNAPSHOT_BASE_URL/$FILENAME
-      wget https://raw.githubusercontent.com/chainlayer/quicksync-playbooks/master/roles/quicksync/files/checksum.sh
-      wget https://get.quicksync.io/$FILENAME.checksum
-      # Compare checksum with onchain version. Hash can be found at https://get.quicksync.io/columbus-3-pruned.DATE.TIME.tar.lz4.hash
-      curl -s https://lcd.terra.dev/txs/`curl -s https://get.quicksync.io/$FILENAME.hash`|jq -r '.tx.value.memo'|sha512sum -c
-      sh ./checksum.sh $FILENAME
 
+      # Download
+      aria2c -x5 $SNAPSHOT_BASE_URL/$FILENAME
+      # Extract
       lz4 -d $FILENAME | tar xf -
 
       # # cleanup
       rm $FILENAME
-      rm checksum.sh
-      rm $FILENAME.checksum
   fi
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 # Default to "data".
-DATADIR="${DATADIR:-data}"
+DATADIR="${DATADIR:-/root/.terra/data}"
 MONIKER="${MONIKER:-docker-node}"
 ENABLE_LCD="${ENABLE_LCD:-true}"
 MINIMUM_GAS_PRICES=${MINIMUM_GAS_PRICES-0.01133uluna,0.15uusd,0.104938usdr,169.77ukrw,428.571umnt,0.125ueur,0.98ucny,16.37ujpy,0.11ugbp,10.88uinr,0.19ucad,0.14uchf,0.19uaud,0.2usgd,4.62uthb,1.25usek,1.25unok,0.9udkk,2180.0uidr,7.6uphp,1.17uhkd}
-SNAPSHOT_NAME="${SNAPSHOT_NAME:-columbus-5-pruned.20211024.0410.tar.lz4}"
+SNAPSHOT_NAME="${SNAPSHOT_NAME}"
 SNAPSHOT_BASE_URL="${SNAPSHOT_BASE_URL:-https://get.quicksync.io}"
 
 # First sed gets the app.toml moved into place.
@@ -18,26 +18,34 @@ if [ "$ENABLE_LCD" = true ] ; then
 fi
 
 # config.toml updates
-sed 's/db_dir = "data"/db_dir = "'"$DATADIR"'"/g' ~/config.toml > ~/.terra/config/config.toml
-sed -i 's/moniker = "moniker"/moniker = "'"$MONIKER"'"/g' ~/.terra/config/config.toml
+
+sed 's/moniker = "moniker"/moniker = "'"$MONIKER"'"/g' ~/config.toml > ~/.terra/config/config.toml
 sed -i 's/laddr = "tcp:\/\/127.0.0.1:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/g' ~/.terra/config/config.toml
-if [ "$CHAINID" = "columbus-5" ] ; then 
+
+if [ "$CHAINID" = "columbus-5" ] && [[ ! -z "$SNAPSHOT_NAME" ]] ; then 
   # Download the snapshot if data directory is empty.
-  path=$(ls -A '~/.terra/data')
+  path=$(ls -A $DATADIR)
   if [[ ! -z "$path" ]]; then
       echo "data directory is NOT empty, skipping quicksync"
   else
       echo "starting snapshot download"
-      cd ~/.terra/
+      mkdir -p $DATADIR
+      cd $DATADIR
       FILENAME="$SNAPSHOT_NAME"
       aria2c -x5 $SNAPSHOT_BASE_URL/$FILENAME
       wget https://raw.githubusercontent.com/chainlayer/quicksync-playbooks/master/roles/quicksync/files/checksum.sh
       wget https://get.quicksync.io/$FILENAME.checksum
       # Compare checksum with onchain version. Hash can be found at https://get.quicksync.io/columbus-3-pruned.DATE.TIME.tar.lz4.hash
       curl -s https://lcd.terra.dev/txs/`curl -s https://get.quicksync.io/$FILENAME.hash`|jq -r '.tx.value.memo'|sha512sum -c
-      chmod +x ./checksum.sh
-      ./checksum.sh $FILENAME
+      sh ./checksum.sh $FILENAME
+
       lz4 -d $FILENAME | tar xf -
+
+      # # cleanup
+      rm $FILENAME
+      rm checksum.sh
+      rm $FILENAME.checksum
   fi
 fi
-exec "$@"
+
+exec "$@" --db_dir $DATADIR


### PR DESCRIPTION
## Summary of changes

The first version of this node attempted to change the `db_dir` value in the config.toml, which ended up not actually working as expected. Instead I've refactored this to use the `--db_dir` flag to specific a different directory and this is working much better. 

I also added to the docs a bit, 

## Report of required housekeeping

- [x] Github issue OR spec proposal link
- [x] Wrote tests
- [x] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [x] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [x] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
