### PR TITLE
TaxCap querier supports url-encoded denoms for ibc

### DIFF
--- a/x/treasury/keeper/querier.go
+++ b/x/treasury/keeper/querier.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"math"
+	"net/url"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -44,12 +45,17 @@ func (q querier) TaxCap(c context.Context, req *types.QueryTaxCapRequest) (*type
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	if err := sdk.ValidateDenom(req.Denom); err != nil {
+	denom, err := url.QueryUnescape(req.Denom)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "failed to unescape denom")
+	}
+
+	if err := sdk.ValidateDenom(denom); err != nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid denom")
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
-	return &types.QueryTaxCapResponse{TaxCap: q.GetTaxCap(ctx, req.Denom)}, nil
+	return &types.QueryTaxCapResponse{TaxCap: q.GetTaxCap(ctx, denom)}, nil
 }
 
 // TaxCaps returns the all tax caps

--- a/x/treasury/keeper/querier_test.go
+++ b/x/treasury/keeper/querier_test.go
@@ -62,6 +62,25 @@ func TestQueryTaxCap(t *testing.T) {
 	require.Equal(t, input.TreasuryKeeper.GetTaxCap(input.Ctx, core.MicroKRWDenom), res.TaxCap)
 }
 
+func TestQueryEncodedIbcTaxCap(t *testing.T) {
+	input := CreateTestInput(t)
+	ctx := sdk.WrapSDKContext(input.Ctx)
+
+	ibcDenomTrace := "ibc%2F28DECFA7FB7E3AB58DC3B3AEA9B11C6C6B6E46356DCC26505205DAD3379984F5"
+
+	taxCap := types.DefaultTaxPolicy.Cap.Amount
+	//input.TreasuryKeeper.SetTaxCap(input.Ctx, ibcDenomTrace, taxCap) // don't set to use default value
+
+	querier := NewQuerier(input.TreasuryKeeper)
+	res, err := querier.TaxCap(ctx, &types.QueryTaxCapRequest{
+		Denom: ibcDenomTrace,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, taxCap, res.TaxCap)
+	require.Equal(t, input.TreasuryKeeper.GetTaxCap(input.Ctx, ibcDenomTrace), res.TaxCap)
+}
+
 func TestQueryTaxCaps(t *testing.T) {
 	input := CreateTestInput(t)
 	ctx := sdk.WrapSDKContext(input.Ctx)


### PR DESCRIPTION
## Summary of changes

support url-encoded denom for `/terra/treasury/v1beta1/tax_caps/{denom}` 

to query tax cap for `ibc/28DECFA7FB7E3AB58DC3B3AEA9B11C6C6B6E46356DCC26505205DAD3379984F5`, 
`terra/treasury/v1beta1/tax_caps/ibc%252F28DECFA7FB7E3AB58DC3B3AEA9B11C6C6B6E46356DCC26505205DAD3379984F5`


## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [x] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
