### PR TITLE
Fix snapshot

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@ MONIKER="${MONIKER:-docker-node}"
 ENABLE_LCD="${ENABLE_LCD:-true}"
 MINIMUM_GAS_PRICES=${MINIMUM_GAS_PRICES-0.01133uluna,0.15uusd,0.104938usdr,169.77ukrw,428.571umnt,0.125ueur,0.98ucny,16.37ujpy,0.11ugbp,10.88uinr,0.19ucad,0.14uchf,0.19uaud,0.2usgd,4.62uthb,1.25usek,1.25unok,0.9udkk,2180.0uidr,7.6uphp,1.17uhkd}
 SNAPSHOT_NAME="${SNAPSHOT_NAME}"
-SNAPSHOT_BASE_URL="${SNAPSHOT_BASE_URL:-https://get.quicksync.io}"
+SNAPSHOT_BASE_URL="${SNAPSHOT_BASE_URL:-https://getsfo.quicksync.io}"
 
 # First sed gets the app.toml moved into place.
 # app.toml updates

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,8 +24,8 @@ sed -i 's/laddr = "tcp:\/\/127.0.0.1:26657"/laddr = "tcp:\/\/0.0.0.0:26657"/g' ~
 
 if [ "$CHAINID" = "columbus-5" ] && [[ ! -z "$SNAPSHOT_NAME" ]] ; then 
   # Download the snapshot if data directory is empty.
-  path=$(ls -A $DATADIR)
-  if [[ ! -z "$path" ]]; then
+  res=$(find "$DATADIR" -name "*.db")
+  if [ "$res" ]; then
       echo "data directory is NOT empty, skipping quicksync"
   else
       echo "starting snapshot download"


### PR DESCRIPTION
## Summary of changes

* Add `sfo` to default quicksync.io URL to use San Francisco as default download region. This is need because `get.quicksync.io` no longer hosts any snapshots. Unless users explicitly sets the `SNAPSHOT_BASE_URL`, snapshots won't work.
* Check for existing of .db files in the `$DATADIR`. Some implementations of k8s filesystem drivers automatically add `.Trash` or `lost+found` directories. The `[[ ! -z ]]` operator will catch these and skip the snapshot. Using `find` to check for explicit `.db` files will tell us if Cosmos has stored any state here yet.

## Report of required housekeeping

- Tested first change by setting `SNAPSHOT_BASE_URL` to `https://getsfo.quicksync.io` explicitly.
- Tested second change by running the entrypoint with a variety of files/dirs on the filesystem, ensuring snapshot did not start if any .db files were present and did start if any other dirs were present (e.g. lost+found)

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
