### PR TITLE
[BugFix] makefile to properly pass RocksDB build options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,13 @@ endif
 ifeq (cleveldb,$(findstring cleveldb,$(COSMOS_BUILD_OPTIONS)))
   build_tags += gcc
 endif
+ifeq (rocksdb,$(findstring rocksdb,$(COSMOS_BUILD_OPTIONS)))
+  build_tags += rocksdb
+endif
+ifeq (boltdb,$(findstring boltdb,$(COSMOS_BUILD_OPTIONS)))
+  build_tags += boltdb
+endif
+
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
@@ -70,13 +77,15 @@ ifeq (badgerdb,$(findstring badgerdb,$(COSMOS_BUILD_OPTIONS)))
 endif
 # handle rocksdb
 ifeq (rocksdb,$(findstring rocksdb,$(COSMOS_BUILD_OPTIONS)))
+  $(info ################################################################)
+  $(info To use rocksdb, you need to install rocksdb first)
+  $(info Please follow this guide https://github.com/rockset/rocksdb-cloud/blob/master/INSTALL.md)
+  $(info ################################################################)
   CGO_ENABLED=1
-  BUILD_TAGS += rocksdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb
 endif
 # handle boltdb
 ifeq (boltdb,$(findstring boltdb,$(COSMOS_BUILD_OPTIONS)))
-  BUILD_TAGS += boltdb
   ldflags += -X github.com/cosmos/cosmos-sdk/types.DBBackend=boltdb
 endif
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Full-node software implementing the Terra protocol<br/><br/>
 - [What is Terra?](#what-is-terra)
 - [Installation](#installation)
   - [Binaries](#binaries)
-  - [From source](#from-source)
+  - [From Source](#from-source)
 - [`terrad`](#terrad)
-- [Node setup](#node-setup)
-  - [Joining the mainnet](#join-the-mainnet)
-  - [Joining a testnet](#join-a-testnet)
-  - [Running a local testnet](#run-a-local-testnet)
-  - [Run a single node testnet](#run-a-local-testnet)
-- [Production environment](#production-environment)
+- [Node Setup](#node-setup)
+  - [Join the mainnet](#join-the-mainnet)
+  - [Join a testnet](#join-a-testnet)
+  - [Run a local testnet](#run-a-local-testnet)
+  - [Run a single node testnet](#run-a-single-node-testnet)
+- [Set up a production environment](#set-up-a-production-environment)
   - [Increase maximum open files](#increase-maximum-open-files)
   - [Create a dedicated user](#create-a-dedicated-user)
   - [Port configuration](#port-configuration)
@@ -100,6 +100,7 @@ git checkout main
 Run the following command to install the executable `terrad` to your `GOPATH` and build Terra Core. `terrad` is the node daemon and CLI for interacting with a Terra node.
 
 ```bash
+# COSMOS_BUILD_OPTIONS=rocksdb make install
 make install
 ```
 

--- a/cmd/terrad/root.go
+++ b/cmd/terrad/root.go
@@ -206,6 +206,11 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 	}
 
 	snapshotDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
+	err = os.MkdirAll(snapshotDir, os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+
 	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary of change
close #653 

* fix makefile to pass RocksDB build option
* create snapshot folder for initializing rocksdb. rocksdb does not create parent folder automatically
* add cmd example for rocksdb build option

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
