### PR TITLE
use --against instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ proto-lint:
 
 ## TODO - change branch release/v0.5.x to master after columbus-5 merged
 proto-check-breaking:
-	@$(DOCKER_BUF) breaking --against-input $(HTTPS_GIT)#branch=master
+	@$(DOCKER_BUF) breaking --against $(HTTPS_GIT)#branch=master
 
 .PHONY: proto-all proto-gen proto-swagger-gen proto-format proto-lint proto-check-breaking 
 


### PR DESCRIPTION
## Summary of changes
Applying suggested flag update
```
Failure: flag --against-input is no longer supported, use --against instead
```
Please see [build output](https://github.com/terra-money/core/runs/4772562041?check_suite_focus=true)
<Describe summary of major changes here>

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
