### PR TITLE
Improve Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t cosmwasm/wasmd:latest
 # docker run --rm -it cosmwasm/wasmd:latest /bin/sh
-FROM golang:1.17-alpine3.14 AS go-builder
+FROM golang:1.17.7-alpine3.15 AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
@@ -21,11 +21,16 @@ RUN sha256sum /lib/libwasmvm_muslc.a | grep 3fc6d5a239f3e97ac96c1a2df3006e4107ca
 # force it to use static lib (from above) not standard libgo_cosmwasm.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc make build
 
-FROM alpine:3.12
+FROM alpine:3.15.0
 
-WORKDIR /root
+RUN addgroup terra \
+    && adduser -G terra -D -h /terra terra
+
+WORKDIR /terra
 
 COPY --from=go-builder /code/build/terrad /usr/local/bin/terrad
+
+USER terra
 
 # rest server
 EXPOSE 1317


### PR DESCRIPTION
In order to improve a bit the Docker image, i suggest to pin the version used in the builder and in the final Docker image.
Another point is to avoid to run container as root. For this, create a dedicated user and run terrad with it.

**HINT**: this could break previous setup running as root because the data will be owned by root. Users will need to change data permissions.

Signed-off-by: Pierre-Emmanuel Andre <pierre-emmanuel.andre@skillz.io>

## Summary of changes

* Pin docker image versions
* Create and use a dedicated user to run the final Docker image

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
