### PR TITLE
Support multi-arch / arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,6 @@
 name: Build & Push
-# Build & Push builds the simapp docker image on every push to master and
-# and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
+# Build & Push builds the Terra Core Docker image on every push to master
+# and publishes the image to https://hub.docker.com/r/terramoney/core/tags
 on:
   pull_request:
   push:
@@ -38,8 +38,14 @@ jobs:
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
           echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=alpine_tags::${TAGS}
+          echo ::set-output name=ubuntu_tags::$(echo ${TAGS} | sed s/core/core-shared/g)
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -50,8 +56,18 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
+      - name: Publish Alpine image to Docker Hub
         uses: docker/build-push-action@v2
         with:
+          file: Dockerfile
           push: ${{ github.event_name != 'pull_request' && !contains(github.ref, 'release') }}
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.prep.outputs.alpine_tags }}
+          platforms: linux/amd64 # does not currently link under arm64
+
+      - name: Publish Ubuntu image to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          file: shared.Dockerfile
+          push: ${{ github.event_name != 'pull_request' && !contains(github.ref, 'release') }}
+          tags: ${{ steps.prep.outputs.ubuntu_tags }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,45 @@
-# docker build . -t cosmwasm/wasmd:latest
-# docker run --rm -it cosmwasm/wasmd:latest /bin/sh
-FROM golang:1.17-alpine3.14 AS go-builder
+ARG RUST_VERSION=1.55.0
+ARG GO_VERSION=1.17
+ARG ALPINE_VERSION=3.14
+ARG BUILD_MODE=src
 
-# this comes from standard alpine nightly file
-#  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
-# with some changes to support our toolchain, etc
-RUN set -eux; apk add --no-cache ca-certificates build-base;
+FROM rust:${RUST_VERSION}-alpine${ALPINE_VERSION} AS rust-builder-src
+WORKDIR /code
 
-RUN apk add git
+# install deps
+RUN apk add --no-cache ca-certificates musl-dev
+
+# build libwasmvm
+ARG WASMVM_VERSION=0.16.5
+ARG WASMVM_SHA256=9db6995f536ecf17aad078b05cebc27a7a950ef0d36f3cb7aa54a02cb4a25833
+RUN set -eux; \
+    wget https://github.com/CosmWasm/wasmvm/archive/refs/tags/v${WASMVM_VERSION}.tar.gz -O wasmvm.tar.gz; \
+    echo "${WASMVM_SHA256} *wasmvm.tar.gz" | sha256sum -c -; \
+    tar xf wasmvm.tar.gz --strip-components=1; \
+    rm wasmvm.tar.gz; \
+    cd libwasmvm; \
+    cargo build --release --example muslc
+
+FROM scratch AS rust-builder-bin
+WORKDIR /code/libwasmvm/target/release/examples/
+
+FROM rust-builder-${BUILD_MODE} AS rust-builder
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS go-builder
+WORKDIR /code
+
+# install deps
+RUN apk add --no-cache ca-certificates build-base git
+
 # NOTE: add these to run with LEDGER_ENABLED=true
 # RUN apk add libusb-dev linux-headers
 
-WORKDIR /code
-COPY . /code/
-
-# See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v0.16.3/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
-RUN sha256sum /lib/libwasmvm_muslc.a | grep 3fc6d5a239f3e97ac96c1a2df3006e4107ca461da4ca318bc71cfdc3e3593125
-
-# force it to use static lib (from above) not standard libgo_cosmwasm.so file
+# build terrad, force static lib
+COPY . /code
+COPY --from=rust-builder /code/libwasmvm/target/release/examples/libmuslc.a /lib/libwasmvm_muslc.a
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc make build
 
-FROM alpine:3.12
-
+FROM alpine:${ALPINE_VERSION} AS release
 WORKDIR /root
 
 COPY --from=go-builder /code/build/terrad /usr/local/bin/terrad

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ go 1.17
 module github.com/terra-money/core
 
 require (
-	github.com/CosmWasm/wasmvm v0.16.3
+	github.com/CosmWasm/wasmvm v0.16.5
 	github.com/cosmos/cosmos-sdk v0.44.5
 	github.com/cosmos/ibc-go v1.1.5
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/wasmvm v0.16.3 h1:hUf33EHRmyyvKMhwVl7nMaAOY0vYJVB4bhU+HPfHfBM=
 github.com/CosmWasm/wasmvm v0.16.3/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
+github.com/CosmWasm/wasmvm v0.16.5/go.mod h1:saGLYYSj6rRVFL6EaWZHzXbLD3Rgn8ZEK+0H+UjKOE4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v0.16.3 h1:hUf33EHRmyyvKMhwVl7nMaAOY0vYJVB4bhU+HPfHfBM=
-github.com/CosmWasm/wasmvm v0.16.3/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
+github.com/CosmWasm/wasmvm v0.16.5 h1:kB1oLoiWpUPnIu5jDqCSYZm+HpXU4si9xfZKgKHKp+8=
 github.com/CosmWasm/wasmvm v0.16.5/go.mod h1:saGLYYSj6rRVFL6EaWZHzXbLD3Rgn8ZEK+0H+UjKOE4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/shared.Dockerfile
+++ b/shared.Dockerfile
@@ -1,24 +1,45 @@
-FROM golang:1.17-buster AS go-builder
+ARG RUST_VERSION=1.55.0
+ARG GO_VERSION=1.17
+ARG BUILD_MODE=src
 
-# Install minimum necessary dependencies, build Cosmos SDK, remove packages
-RUN apt update
-RUN apt install -y curl git build-essential
-# debug: for live editting in the image
-RUN apt install -y vim
-
+FROM rust:${RUST_VERSION}-buster AS rust-builder-src
 WORKDIR /code
-COPY . /code/
 
+# build libwasmvm
+ARG WASMVM_VERSION=0.16.5
+ARG WASMVM_SHA256=9db6995f536ecf17aad078b05cebc27a7a950ef0d36f3cb7aa54a02cb4a25833
+RUN set -eux; \
+    wget https://github.com/CosmWasm/wasmvm/archive/refs/tags/v${WASMVM_VERSION}.tar.gz -O wasmvm.tar.gz; \
+    echo "${WASMVM_SHA256} *wasmvm.tar.gz" | sha256sum -c -; \
+    tar xf wasmvm.tar.gz --strip-components=1; \
+    rm wasmvm.tar.gz; \
+    cd libwasmvm; \
+    cargo build --release
+
+# support pre-built libwasmvm using the arg BUILD_MODE=bin
+FROM scratch AS rust-builder-bin
+WORKDIR /code/libwasmvm/target/release/deps
+COPY libwasmvm.so ./
+
+FROM rust-builder-${BUILD_MODE} AS rust-builder
+
+FROM golang:${GO_VERSION}-buster AS go-builder
+WORKDIR /code
+
+# install deps
+RUN apt update && \
+    apt install -y curl git build-essential vim
+
+# build terrad
+COPY . /code
+COPY --from=rust-builder /code/libwasmvm/target/release/deps/libwasmvm.so /lib/libwasmvm.so
 RUN LEDGER_ENABLED=false make build
 
-RUN cp /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/api/libwasmvm.so /lib/libwasmvm.so
-
-FROM ubuntu:20.04
-
+FROM ubuntu:20.04 AS release
 WORKDIR /root
 
+COPY --from=rust-builder /code/libwasmvm/target/release/deps/libwasmvm.so /lib/libwasmvm.so
 COPY --from=go-builder /code/build/terrad /usr/local/bin/terrad
-COPY --from=go-builder /lib/libwasmvm.so /lib/libwasmvm.so
 
 # rest server
 EXPOSE 1317


### PR DESCRIPTION
This PR adds support for multi-arch / arm64 builds.

- chore: Bump wasmvm to v0.16.5
- build: Compile libwasmvm from source
- ci: Build & publish multi-arch images
