### PR TITLE
[Feature] Add oracle slash event

### DIFF
--- a/x/oracle/types/events.go
+++ b/x/oracle/types/events.go
@@ -16,5 +16,6 @@ const (
 	AttributeKeyOperator      = "operator"
 	AttributeKeyFeeder        = "feeder"
 
-	AttributeValueCategory = ModuleName
+	AttributeValueCategory          = ModuleName
+	AttributeValueMissingOracleVote = "missing_oracle_vote"
 )


### PR DESCRIPTION
## Summary of changes

When a validator is jailed due to oracle miss, currently there is no event left.
To solve, we just add slash events when a validator jailed due to oracle miss. 

I believe adding end_block events does not affect to consensus state, but need to confirm this.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
