### PR TITLE
Optimising ValidateFeeder() and fixing typos in error wrapper

### DIFF
--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -350,11 +350,9 @@ func (k Keeper) ClearTobinTaxes(ctx sdk.Context) {
 
 // ValidateFeeder return the given feeder is allowed to feed the message or not
 func (k Keeper) ValidateFeeder(ctx sdk.Context, feederAddr sdk.AccAddress, validatorAddr sdk.ValAddress) error {
-	if !feederAddr.Equals(validatorAddr) {
-		delegate := k.GetFeederDelegation(ctx, validatorAddr)
-		if !delegate.Equals(feederAddr) {
-			return sdkerrors.Wrap(types.ErrNoVotingPermission, feederAddr.String())
-		}
+	delegate := k.GetFeederDelegation(ctx, validatorAddr)
+	if !delegate.Equals(feederAddr) {
+		return sdkerrors.Wrap(types.ErrNoVotingPermission, feederAddr.String())
 	}
 
 	// Check that the given validator exists

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -157,7 +157,7 @@ func (k Keeper) GetContractInfo(ctx sdk.Context, contractAddress sdk.AccAddress)
 	store := ctx.KVStore(k.storeKey)
 	contractBz := store.Get(types.GetContractInfoKey(contractAddress))
 	if contractBz == nil {
-		return types.ContractInfo{}, sdkerrors.Wrapf(types.ErrNotFound, "constractInfo %s", contractAddress.String())
+		return types.ContractInfo{}, sdkerrors.Wrapf(types.ErrNotFound, "contractInfo %s", contractAddress.String())
 	}
 	k.cdc.MustUnmarshal(contractBz, &contractInfo)
 	return contractInfo, nil


### PR DESCRIPTION
## Summary of changes

1. Optimising `ValidateFeeder()`
The `feeder` is expected and enforced to be a `AccAddressFromBech32` rather than `ValAddressFromBech32`. This is declared at the following logic in the `x/oracle/keeper/msg_server.go#65` and `x/oracle/keeper/keeper.go#136.`
The `ValidateFeeder()` was not efficient  since the first case would always failed and it would always pull the `GetFeederDelegation` from the store.

2. Fixed a typo in GetContractInfo() sdk error wrapper. `constractInfo` -> `contractInfo`

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Updated API documentation (client/lcd/swagger-ui/swagger.yaml)
- [ ] Added a relevant changelog entry: clog add [section] [stanza] [message]

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
