### PR TITLE
tm-db: reduce the compaction time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,6 +131,6 @@ replace (
 	github.com/cosmos/iavl => github.com/cosmos/iavl v0.17.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/terra-money/tendermint v0.34.19-terra.2
-	github.com/tendermint/tm-db => github.com/terra-money/tm-db v0.6.7-terra.0
+	github.com/tendermint/tm-db => github.com/terra-money/tm-db v0.6.7-terra.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -969,8 +969,8 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/terra-money/tendermint v0.34.19-terra.2 h1:9yjByhjsr1cu91NtRLDfu1attbCUtaOJZUj22bILLig=
 github.com/terra-money/tendermint v0.34.19-terra.2/go.mod h1:R5+wgIwSxMdKQcmOaeudL0Cjkr3HDkhpcdum6VeU3R4=
-github.com/terra-money/tm-db v0.6.7-terra.0 h1:IA/M6uVXkP8Yw3HMUZDBvY5etqBXqaDJIHZEDF0Z8EU=
-github.com/terra-money/tm-db v0.6.7-terra.0/go.mod h1:XDmmlTVFYkJdES7JbhtkWP5H3M9YzpGZvyJ6pQK5N5Q=
+github.com/terra-money/tm-db v0.6.7-terra.1 h1:RaxvveLTJhfn1jwQetRGmw73d9pVHWtoOU+mJZjVTWc=
+github.com/terra-money/tm-db v0.6.7-terra.1/go.mod h1:XDmmlTVFYkJdES7JbhtkWP5H3M9YzpGZvyJ6pQK5N5Q=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
## Description
Previous goleveldb options that I modified was a little too much, increasing compaction time. Below are the changed options.

name|value
-- | --
TableSize | 2
TableSizeMult | 2
TotalSize | 20
TotalSizeMult | 10




 level | 1 | 2 | 3 | 4 | 5 | 6
-- | -- | -- | -- | -- | -- | --
TableSize | 4 | 8 | 16 | 32 | 64 | 128
TotalSize | 200 | 2000 | 20000 | 200000 | 2000000 | 20000000

