### PR TITLE
exclude validator addresses from being genesis staking

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -871,12 +871,13 @@ func (app *TerraApp) enforceStakingForVestingTokens(ctx sdk.Context, genesisStat
 			panic(err)
 		}
 
-		// skip genesis staking if the vesting account is validator address
-		if _, ok := validatorAccAddressMap[account.GetAddress().String()]; ok {
-			continue
-		}
-
 		if vestingAcc, ok := account.(vestingexported.VestingAccount); ok {
+
+			// skip genesis staking if the vesting account is validator address
+			if _, ok := validatorAccAddressMap[account.GetAddress().String()]; ok {
+				continue
+			}
+
 			amt := vestingAcc.GetOriginalVesting().AmountOf(app.StakingKeeper.BondDenom(ctx))
 
 			// to prevent staking multiple times over the same validator

--- a/app/app.go
+++ b/app/app.go
@@ -874,7 +874,7 @@ func (app *TerraApp) enforceStakingForVestingTokens(ctx sdk.Context, genesisStat
 		if vestingAcc, ok := account.(vestingexported.VestingAccount); ok {
 
 			// skip genesis staking if the vesting account is validator address
-			if _, ok := validatorAccAddressMap[account.GetAddress().String()]; ok {
+			if _, ok := validatorAccAddressMap[vestingAcc.GetAddress().String()]; ok {
 				continue
 			}
 


### PR DESCRIPTION
## What's changed

Validator account can have vesting if they use classic addresses to make validator. If they make `gentx` with vesting tokens, the genesis staking steps will be failed because the tokens are already in use. 

To prevent that case, exclude validators from being genesis staking.