### PR TITLE
Revert "exclude validator addresses from being genesis staking"

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -842,17 +842,13 @@ func (app *TerraApp) enforceStakingForVestingTokens(ctx sdk.Context, genesisStat
 
 	allValidators := app.StakingKeeper.GetAllValidators(ctx)
 
+	// Filter out validators which have huge max commission than 20%
 	var validators []stakingtypes.Validator
-	validatorAccAddressMap := make(map[string]bool)
 	maxCommissionCondition := sdk.NewDecWithPrec(20, 2)
 	for _, val := range allValidators {
-
-		// Filter out validators which have huge max commission than 20%
 		if val.Commission.CommissionRates.MaxRate.LTE(maxCommissionCondition) {
 			validators = append(validators, val)
 		}
-
-		validatorAccAddressMap[sdk.AccAddress(val.GetOperator()).String()] = true
 	}
 
 	validatorLen := len(validators)
@@ -872,12 +868,6 @@ func (app *TerraApp) enforceStakingForVestingTokens(ctx sdk.Context, genesisStat
 		}
 
 		if vestingAcc, ok := account.(vestingexported.VestingAccount); ok {
-
-			// skip genesis staking if the vesting account is validator address
-			if _, ok := validatorAccAddressMap[vestingAcc.GetAddress().String()]; ok {
-				continue
-			}
-
 			amt := vestingAcc.GetOriginalVesting().AmountOf(app.StakingKeeper.BondDenom(ctx))
 
 			// to prevent staking multiple times over the same validator


### PR DESCRIPTION
Reverts terra-money/core#19

we will exclude validator's gentx if the validator address is vesting account.