### PR TITLE
Revert "Cleanup"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,26 +1,34 @@
-name: golangci-lint
+name: Lint
+# Lint runs golangci-lint over the entire Gaia repository
+# This workflow is run on every pull request and push to main
+# The `golangci` job will pass without running if no *.{go, mod, sum} files have been modified.
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-      - main
   pull_request:
-permissions:
-  contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
+  push:
+    branches:
+      - main
+      - master
+      - "release/*"
 jobs:
   golangci:
-    name: lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: technote-space/get-diff-action@v4
         with:
-          version: latest
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.45.2
+          args: --timeout 10m
+          github-token: ${{ secrets.github_token }}
+        if: "env.GIT_DIFF != ''"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,26 @@
-run:
-  tests: true
-  timeout: 10m
-  sort-results: true
-  allow-parallel-runners: true
-  concurrency: 4
-
 linters:
   disable-all: true
   enable:
-    - depguard
-    - dogsled
-    - exportloopref
-    - goconst
-    - gocritic
-    - gofumpt
-    - gosec
-    - gosimple
-    - govet
+    - errcheck
+    - golint
     - ineffassign
-    - misspell
-    - nakedret
-    - nolintlint
-    - staticcheck
-    - revive
-    - stylecheck
-    - typecheck
     - unconvert
-    - unused
+    - misspell
+    - govet
+    # - unused
+    # - deadcode
+    - goconst
+    - gosec
+    # - staticcheck
+linters-settings:
+  gocyclo:
+    min-complexity: 11
+  errcheck:
+    ignore: fmt:.*,io/ioutil:^Read.*,github.com/spf13/cobra:MarkFlagRequired,github.com/spf13/viper:BindPFlag
+  golint:
+    min-confidence: 1.1
+issues:
+  exclude:
+    - composite
+run:
+  tests: false

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -1,6 +1,8 @@
 package ante_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -11,12 +13,14 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	terraapp "github.com/terra-money/core/v2/app"
@@ -112,4 +116,41 @@ func (suite *AnteTestSuite) CreateTestTx(privs []cryptotypes.PrivKey, accNums []
 
 func TestAnteTestSuite(t *testing.T) {
 	suite.Run(t, new(AnteTestSuite))
+}
+
+func generatePubKeysAndSignatures(n int, msg []byte, _ bool) (pubkeys []cryptotypes.PubKey, signatures [][]byte) {
+	pubkeys = make([]cryptotypes.PubKey, n)
+	signatures = make([][]byte, n)
+	for i := 0; i < n; i++ {
+		var privkey cryptotypes.PrivKey = secp256k1.GenPrivKey()
+
+		// TODO: also generate ed25519 keys as below when ed25519 keys are
+		//  actually supported, https://github.com/cosmos/cosmos-sdk/issues/4789
+		// for now this fails:
+		//if rand.Int63()%2 == 0 {
+		//	privkey = ed25519.GenPrivKey()
+		//} else {
+		//	privkey = secp256k1.GenPrivKey()
+		//}
+
+		pubkeys[i] = privkey.PubKey()
+		signatures[i], _ = privkey.Sign(msg)
+	}
+	return
+}
+
+func expectedGasCostByKeys(pubkeys []cryptotypes.PubKey) uint64 {
+	cost := uint64(0)
+	for _, pubkey := range pubkeys {
+		pubkeyType := strings.ToLower(fmt.Sprintf("%T", pubkey))
+		switch {
+		case strings.Contains(pubkeyType, "ed25519"):
+			cost += types.DefaultParams().SigVerifyCostED25519
+		case strings.Contains(pubkeyType, "secp256k1"):
+			cost += types.DefaultParams().SigVerifyCostSecp256k1
+		default:
+			panic("unexpected key type")
+		}
+	}
+	return cost
 }

--- a/app/ante/sigverify.go
+++ b/app/ante/sigverify.go
@@ -18,6 +18,7 @@ var (
 	// simulation signature values used to estimate gas consumption
 	key                = make([]byte, secp256k1.PubKeySize)
 	simSecp256k1Pubkey = &secp256k1.PubKey{Key: key}
+	simSecp256k1Sig    [64]byte
 
 	_ authsigning.SigVerifiableTx = (*legacytx.StdTx)(nil) // assert StdTx implements SigVerifiableTx
 )

--- a/app/app.go
+++ b/app/app.go
@@ -223,7 +223,9 @@ var (
 	}
 )
 
-var _ servertypes.Application = (*TerraApp)(nil)
+var (
+	_ servertypes.Application = (*TerraApp)(nil)
+)
 
 func init() {
 	userHomeDir, err := os.UserHomeDir()
@@ -842,6 +844,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 // enforceStakingForVestingTokens enforce vesting tokens to be staked
 // CONTRACT: validator's gentx account must not be a vesting account
 func (app *TerraApp) enforceStakingForVestingTokens(ctx sdk.Context, genesisState GenesisState) {
+
 	var authState authtypes.GenesisState
 	app.appCodec.MustUnmarshalJSON(genesisState[authtypes.ModuleName], &authState)
 

--- a/app/export.go
+++ b/app/export.go
@@ -49,8 +49,7 @@ func (app *TerraApp) ExportAppStateAndValidators(
 
 // prepare for fresh start at zero height
 // NOTE zero height genesis is a temporary feature which will be deprecated
-//
-//	in favour of export at a block height
+//      in favour of export at a block height
 func (app *TerraApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 

--- a/app/tx/broadcast.go
+++ b/app/tx/broadcast.go
@@ -3,7 +3,7 @@ package tx
 import (
 	"errors"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -43,7 +43,7 @@ func BroadcastTxRequest(clientCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req BroadcastReq
 
-		body, err := io.ReadAll(r.Body)
+		body, err := ioutil.ReadAll(r.Body)
 		if rest.CheckBadRequestError(w, err) {
 			return
 		}
@@ -96,7 +96,7 @@ func BroadcastTxRequest(clientCtx client.Context) http.HandlerFunc {
 
 		// check the sequence nubmer is equal with the signature nubmer
 		if len(signatures) != len(req.Sequences) {
-			rest.CheckBadRequestError(w, errors.New("must provide each signers's sequence number"))
+			rest.CheckBadRequestError(w, errors.New("Must provide each signers's sequence number"))
 			return
 		}
 

--- a/client/docs/statik/init.go
+++ b/client/docs/statik/init.go
@@ -1,0 +1,3 @@
+package statik
+
+//This just for fixing the error in importing empty github.com/cosmos/cosmos-sdk/client/lcd/statik

--- a/cmd/terrad/root.go
+++ b/cmd/terrad/root.go
@@ -253,8 +253,8 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 
 func (a appCreator) appExport(
 	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailAllowedAddrs []string,
-	appOpts servertypes.AppOptions,
-) (servertypes.ExportedApp, error) {
+	appOpts servertypes.AppOptions) (servertypes.ExportedApp, error) {
+
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)
 	if !ok || homePath == "" {
 		return servertypes.ExportedApp{}, errors.New("application home not set")


### PR DESCRIPTION
Hello Team,

Thanks @faddat for submitting the https://github.com/terra-money/core/pull/98 and @gregnuj  for reviewing the PR. Unfortunately we have to revert the PR since this other PR https://github.com/terra-money/core/pull/106 contains a major upgrade on core. 

The https://github.com/terra-money/core/pull/106 already contains the fixes for the linter and some of the files that were modified aren't existing anymore (app/ante/ante_test.go, app/ante/sigverify.go and app/tx/broadcast.go
). But please feel free to keep contributing any help is very welcome.

Reverts terra-money/core#98