### PR TITLE
fix: ibc-hooks callback not triggering wasm callback

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -500,20 +500,6 @@ func NewTerraApp(
 		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
 		AddRoute(alliancetypes.RouterKey, alliance.NewAllianceProposalHandler(app.AllianceKeeper))
 
-	// Create Transfer Keepers
-	app.TransferKeeper = ibctransferkeeper.NewKeeper(
-		appCodec,
-		keys[ibctransfertypes.StoreKey],
-		app.GetSubspace(ibctransfertypes.ModuleName),
-		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.ChannelKeeper,
-		&app.IBCKeeper.PortKeeper,
-		app.AccountKeeper,
-		app.BankKeeper,
-		scopedTransferKeeper,
-	)
-	transferIBCModule := ibctransfer.NewIBCModule(app.TransferKeeper)
-
 	// Configure the hooks keeper
 	hooksKeeper := ibchookskeeper.NewKeeper(
 		keys[ibchookstypes.StoreKey],
@@ -525,6 +511,20 @@ func NewTerraApp(
 		app.IBCKeeper.ChannelKeeper,
 		app.Ics20WasmHooks,
 	)
+
+	// Create Transfer Keepers
+	app.TransferKeeper = ibctransferkeeper.NewKeeper(
+		appCodec,
+		keys[ibctransfertypes.StoreKey],
+		app.GetSubspace(ibctransfertypes.ModuleName),
+		app.HooksICS4Wrapper,
+		app.IBCKeeper.ChannelKeeper,
+		&app.IBCKeeper.PortKeeper,
+		app.AccountKeeper,
+		app.BankKeeper,
+		scopedTransferKeeper,
+	)
+	transferIBCModule := ibctransfer.NewIBCModule(app.TransferKeeper)
 
 	// Hooks Middleware
 	hooksTransferStack := ibchooks.NewIBCMiddleware(&transferIBCModule, &app.HooksICS4Wrapper)

--- a/x/ibc-hooks/wasm_hook.go
+++ b/x/ibc-hooks/wasm_hook.go
@@ -253,7 +253,7 @@ func (h WasmHooks) SendPacketOverride(i ICS4Middleware, ctx sdk.Context, chanCap
 	} else {
 		icsdata.Memo = stringMetadata
 	}
-	dataBytes, err := json.Marshal(data)
+	dataBytes, err := json.Marshal(icsdata)
 	if err != nil {
 		return 0, sdkerrors.Wrap(err, "Send packet with callback error")
 	}


### PR DESCRIPTION
IBC hooks wasn't triggering callbacks even when `memo` was set with the contract address. The issue was due to a misconfiguration of the transfer module not given the ICS4_middleware with IBC hooks included. 

Also fixed another bug in which memo did not excluded the key `ibc_callback` for backwards compatibility. 