### PR TITLE
fix: update plan name for pisco

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1009,7 +1009,7 @@ func (app *TerraApp) RegisterUpgradeHandlers(cfg module.Configurator) {
 		v2_3_0.CreateUpgradeHandler(app.mm, app.configurator, app.TokenFactoryKeeper),
 	)
 	app.UpgradeKeeper.SetUpgradeHandler(
-		terraappconfig.Upgrade2_4,
+		terraappconfig.Upgrade2_4_rc4,
 		v2_4.CreateUpgradeHandler(app.mm, app.configurator),
 	)
 }

--- a/app/config/const.go
+++ b/app/config/const.go
@@ -47,7 +47,8 @@ const (
 	WasmMsgMigrateContract              = "/cosmwasm.wasm.v1.MsgMigrateContract"
 
 	// UpgradeName gov proposal name
-	Upgrade2_2_0 = "2.2.0"
-	Upgrade2_3_0 = "2.3.0"
-	Upgrade2_4   = "v2.4"
+	Upgrade2_2_0   = "2.2.0"
+	Upgrade2_3_0   = "2.3.0"
+	Upgrade2_4     = "v2.4"
+	Upgrade2_4_rc4 = "2.4.0-rc4"
 )


### PR DESCRIPTION
The wrong upgrade name was used in the pisco chain upgrade. Updating the build to reflect that new planname