### PR TITLE
feat: module version

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -884,6 +884,7 @@ func (app *TerraApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abc
 		panic(err)
 	}
 	res := app.mm.InitGenesis(ctx, app.appCodec, genesisState)
+	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
 
 	// stake all vesting tokens
 	app.enforceStakingForVestingTokens(ctx, genesisState)


### PR DESCRIPTION
On a previous commit (https://github.com/terra-money/core/commit/a511f8c133568f9ca7a774db0793c6a7379116cf)  the line of code SetModuleVersionMap was deleted by mistake. This causes an error when a new chain is created and wants to be updated because the module versions are not available to upgrade.
