### PR TITLE
Fix/pisco upgrade 2.5

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1143,6 +1143,11 @@ func (app *TerraApp) RegisterUpgradeHandlers(cfg module.Configurator) {
 		terraappconfig.Upgrade2_3_0,
 		v2_3_0.CreateUpgradeHandler(app.mm, app.configurator, app.TokenFactoryKeeper),
 	)
+	// This is pisco only since an incorrect plan name was used for the upgrade
+	app.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_4_rc,
+		v2_4.CreateUpgradeHandler(app.mm, app.configurator),
+	)
 	app.UpgradeKeeper.SetUpgradeHandler(
 		terraappconfig.Upgrade2_4,
 		v2_4.CreateUpgradeHandler(app.mm, app.configurator),

--- a/app/config/const.go
+++ b/app/config/const.go
@@ -47,8 +47,9 @@ const (
 	WasmMsgMigrateContract              = "/cosmwasm.wasm.v1.MsgMigrateContract"
 
 	// UpgradeName gov proposal name
-	Upgrade2_2_0 = "2.2.0"
-	Upgrade2_3_0 = "2.3.0"
-	Upgrade2_4   = "v2.4"
-	Upgrade2_5   = "v2.5"
+	Upgrade2_2_0  = "2.2.0"
+	Upgrade2_3_0  = "2.3.0"
+	Upgrade2_4_rc = "2.4.0-rc4" // This is pisco only since an incorrect plan name was used for the upgrade
+	Upgrade2_4    = "v2.4"
+	Upgrade2_5    = "v2.5"
 )


### PR DESCRIPTION
Due to an incorrect plan name during the 2.4 upgrade, pisco upgrade to 2.5 will fail since the incorrect plan is not registered in this version.

Adding the handler here so that the check will pass.