### PR TITLE
fix: v2.6 migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,6 @@ integration-test-all: init-test-framework \
 	test-relayer \
 	test-ica \
 	test-ibc-hooks \
-	test-vesting-accounts \
 	test-tokenfactory 
 
 init-test-framework: clean-testing-data install

--- a/app/app.go
+++ b/app/app.go
@@ -992,6 +992,13 @@ func NewTerraApp(
 			},
 		}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	} else if upgradeInfo.Name == terraappconfig.Upgrade2_6 && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{
+				feesharetypes.StoreKey,
+			},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 
 	if loadLatest {
@@ -1194,6 +1201,7 @@ func (app *TerraApp) RegisterUpgradeHandlers(cfg module.Configurator) {
 			app.appCodec,
 			app.IBCKeeper.ClientKeeper,
 			app.AccountKeeper,
+			app.FeeShareKeeper,
 		),
 	)
 }

--- a/app/upgrades/v2.6/upgrade.go
+++ b/app/upgrades/v2.6/upgrade.go
@@ -15,6 +15,8 @@ import (
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 	pobtypes "github.com/skip-mev/pob/x/builder/types"
+	feesharekeeper "github.com/terra-money/core/v2/x/feeshare/keeper"
+	feesharetypes "github.com/terra-money/core/v2/x/feeshare/types"
 )
 
 func CreateUpgradeHandler(
@@ -23,8 +25,12 @@ func CreateUpgradeHandler(
 	cdc codec.Codec,
 	clientKeeper clientkeeper.Keeper,
 	authKeeper authkeeper.AccountKeeper,
+	feesharekeeper feesharekeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// feeshare module is a new module added in v2.6,
+		// we need to set the default params
+		feesharekeeper.SetParams(ctx, feesharetypes.DefaultParams())
 
 		// overwrite pob account to a module account for pisco-1
 		overwritePobModuleAccount(ctx, authKeeper)
@@ -43,9 +49,16 @@ func overwritePobModuleAccount(ctx sdk.Context, authKeeper authkeeper.AccountKee
 	if ctx.ChainID() == "pisco-1" {
 		macc := authtypes.NewEmptyModuleAccount(pobtypes.ModuleName)
 		pobaccount := authKeeper.GetAccount(ctx, macc.GetAddress())
-		macc.AccountNumber = pobaccount.GetAccountNumber()
-		maccI := (authKeeper.NewAccount(ctx, macc)).(authtypes.ModuleAccountI)
-		authKeeper.SetModuleAccount(ctx, maccI)
+		// if pob account exists, overwrite it
+		// if not, create a new one
+		if pobaccount != nil {
+			macc.AccountNumber = pobaccount.GetAccountNumber()
+			maccI := (authKeeper.NewAccount(ctx, macc)).(authtypes.ModuleAccountI)
+			authKeeper.SetModuleAccount(ctx, maccI)
+		} else {
+			maccI := (authKeeper.NewAccount(ctx, macc)).(authtypes.ModuleAccountI)
+			authKeeper.SetModuleAccount(ctx, maccI)
+		}
 	}
 }
 

--- a/app/upgrades/v2.6/upgrade.go
+++ b/app/upgrades/v2.6/upgrade.go
@@ -30,13 +30,15 @@ func CreateUpgradeHandler(
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		// feeshare module is a new module added in v2.6,
 		// we need to set the default params
-		feesharekeeper.SetParams(ctx, feesharetypes.DefaultParams())
-
+		err := feesharekeeper.SetParams(ctx, feesharetypes.DefaultParams())
+		if err != nil {
+			return nil, err
+		}
 		// overwrite pob account to a module account for pisco-1
 		overwritePobModuleAccount(ctx, authKeeper)
 
 		// Increase the unbonding period for atlantic-2
-		err := increaseUnbondingPeriod(ctx, cdc, clientKeeper)
+		err = increaseUnbondingPeriod(ctx, cdc, clientKeeper)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Initiate feeshare module store and check if  POB account exists for pisco-1