### PR TITLE
chore: core refact app

### DIFF
--- a/app/app_test/app_test.go
+++ b/app/app_test/app_test.go
@@ -309,7 +309,7 @@ func TestSimAppEnforceStakingForVestingTokens(t *testing.T) {
 	ctx := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
 
 	genesisState[authtypes.ModuleName] = app.GetAppCodec().MustMarshalJSON(authtypes.NewGenesisState(authtypes.DefaultParams(), genAccounts))
-	delegations := app.StakingKeeper.GetAllDelegations(ctx)
+	delegations := app.Keepers.StakingKeeper.GetAllDelegations(ctx)
 	sharePerValidators := make(map[string]sdk.Dec)
 
 	for _, del := range delegations {

--- a/app/app_test/test_helpers.go
+++ b/app/app_test/test_helpers.go
@@ -68,19 +68,19 @@ func (s *AppTestSuite) Setup() {
 		GRPCQueryRouter: s.App.GRPCQueryRouter(),
 		Ctx:             s.Ctx,
 	}
-	err := s.App.BankKeeper.SetParams(s.Ctx, banktypes.NewParams(true))
+	err := s.App.Keepers.BankKeeper.SetParams(s.Ctx, banktypes.NewParams(true))
 	s.Require().NoError(err)
 
-	err = s.App.WasmKeeper.SetParams(s.Ctx, wasmtypes.DefaultParams())
+	err = s.App.Keepers.WasmKeeper.SetParams(s.Ctx, wasmtypes.DefaultParams())
 	s.Require().NoError(err)
 
-	err = s.App.FeeShareKeeper.SetParams(s.Ctx, feesharetypes.DefaultParams())
+	err = s.App.Keepers.FeeShareKeeper.SetParams(s.Ctx, feesharetypes.DefaultParams())
 	s.Require().NoError(err)
 
-	err = s.App.TokenFactoryKeeper.SetParams(s.Ctx, tokenfactorytypes.DefaultParams())
+	err = s.App.Keepers.TokenFactoryKeeper.SetParams(s.Ctx, tokenfactorytypes.DefaultParams())
 	s.Require().NoError(err)
 
-	s.App.DistrKeeper.SetFeePool(s.Ctx, distrtypes.InitialFeePool())
+	s.App.Keepers.DistrKeeper.SetFeePool(s.Ctx, distrtypes.InitialFeePool())
 
 	s.TestAccs = s.CreateRandomAccounts(3)
 }
@@ -114,11 +114,11 @@ func (s *AppTestSuite) CreateRandomAccounts(numAccts int) []sdk.AccAddress {
 // FundAcc funds target address with specified amount.
 func (s *AppTestSuite) FundAcc(acc sdk.AccAddress, amounts sdk.Coins) (err error) {
 	s.Require().NoError(err)
-	if err := s.App.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, amounts); err != nil {
+	if err := s.App.Keepers.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, amounts); err != nil {
 		return err
 	}
 
-	return s.App.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, minttypes.ModuleName, acc, amounts)
+	return s.App.Keepers.BankKeeper.SendCoinsFromModuleToAccount(s.Ctx, minttypes.ModuleName, acc, amounts)
 }
 
 func SetupGenesisValSet(

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -1,0 +1,606 @@
+package keepers
+
+import (
+
+	// #nosec G702
+
+	"path/filepath"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/server"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
+	feegrantkeeper "github.com/cosmos/cosmos-sdk/x/feegrant/keeper"
+	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	"github.com/cosmos/cosmos-sdk/x/upgrade"
+	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router"
+	ibctransfer "github.com/cosmos/ibc-go/v7/modules/apps/transfer"
+	ibcclient "github.com/cosmos/ibc-go/v7/modules/core/02-client"
+	ibcclienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	"github.com/spf13/cast"
+
+	"github.com/cosmos/cosmos-sdk/x/feegrant"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+
+	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	routerkeeper "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/keeper"
+	routertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/types"
+
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	icq "github.com/cosmos/ibc-apps/modules/async-icq/v7"
+	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
+	icahostkeeper "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/keeper"
+	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
+	ibcfeekeeper "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/keeper"
+	ibcfeetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
+	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+
+	icqkeeper "github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
+	ibcfee "github.com/cosmos/ibc-go/v7/modules/apps/29-fee"
+	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
+
+	ibchooks "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7"
+	ibchookskeeper "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7/keeper"
+	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	icahost "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host"
+
+	icacontroller "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller"
+	icacontrollerkeeper "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/keeper"
+	tokenfactorykeeper "github.com/terra-money/core/v2/x/tokenfactory/keeper"
+	tokenfactorytypes "github.com/terra-money/core/v2/x/tokenfactory/types"
+
+	pobtype "github.com/skip-mev/pob/x/builder/types"
+	"github.com/terra-money/alliance/x/alliance"
+	alliancekeeper "github.com/terra-money/alliance/x/alliance/keeper"
+	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
+	custombankkeeper "github.com/terra-money/core/v2/custom/bank/keeper"
+	feesharekeeper "github.com/terra-money/core/v2/x/feeshare/keeper"
+	feesharetypes "github.com/terra-money/core/v2/x/feeshare/types"
+
+	pobkeeper "github.com/skip-mev/pob/x/builder/keeper"
+
+	terraappconfig "github.com/terra-money/core/v2/app/config"
+	// unnamed import of statik for swagger UI support
+	_ "github.com/terra-money/core/v2/client/docs/statik"
+)
+
+var wasmCapabilities = "iterator,staking,stargate,token_factory,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4"
+
+// module account permissions
+var maccPerms = map[string][]string{
+	authtypes.FeeCollectorName:     nil,
+	distrtypes.ModuleName:          nil,
+	icatypes.ModuleName:            nil,
+	minttypes.ModuleName:           {authtypes.Minter},
+	stakingtypes.BondedPoolName:    {authtypes.Burner, authtypes.Staking},
+	stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
+	govtypes.ModuleName:            {authtypes.Burner},
+	ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
+	ibcfeetypes.ModuleName:         nil,
+	icqtypes.ModuleName:            nil,
+	wasmtypes.ModuleName:           {authtypes.Burner},
+	tokenfactorytypes.ModuleName:   {authtypes.Burner, authtypes.Minter},
+	alliancetypes.ModuleName:       {authtypes.Burner, authtypes.Minter},
+	alliancetypes.RewardsPoolName:  nil,
+	pobtype.ModuleName:             nil,
+}
+
+type TerraAppKeepers struct {
+	// Stores Keys
+	keys    map[string]*storetypes.KVStoreKey
+	tkeys   map[string]*storetypes.TransientStoreKey
+	memKeys map[string]*storetypes.MemoryStoreKey
+
+	// keepers
+	AccountKeeper         authkeeper.AccountKeeper
+	BankKeeper            custombankkeeper.Keeper
+	CapabilityKeeper      *capabilitykeeper.Keeper
+	StakingKeeper         *stakingkeeper.Keeper
+	SlashingKeeper        slashingkeeper.Keeper
+	MintKeeper            mintkeeper.Keeper
+	DistrKeeper           distrkeeper.Keeper
+	GovKeeper             govkeeper.Keeper
+	CrisisKeeper          crisiskeeper.Keeper
+	UpgradeKeeper         *upgradekeeper.Keeper
+	ParamsKeeper          paramskeeper.Keeper
+	ConsensusParamsKeeper consensusparamkeeper.Keeper
+	IBCKeeper             *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	EvidenceKeeper        evidencekeeper.Keeper
+	TransferKeeper        ibctransferkeeper.Keeper
+	AuthzKeeper           authzkeeper.Keeper
+	FeeGrantKeeper        feegrantkeeper.Keeper
+	ICAControllerKeeper   icacontrollerkeeper.Keeper
+	ICAHostKeeper         icahostkeeper.Keeper
+	IBCFeeKeeper          ibcfeekeeper.Keeper
+	RouterKeeper          routerkeeper.Keeper
+	TokenFactoryKeeper    tokenfactorykeeper.Keeper
+	AllianceKeeper        alliancekeeper.Keeper
+	FeeShareKeeper        feesharekeeper.Keeper
+	ICQKeeper             icqkeeper.Keeper
+
+	// IBC hooks
+	IBCHooksKeeper   *ibchookskeeper.Keeper
+	TransferStack    porttypes.Middleware
+	Ics20WasmHooks   *ibchooks.WasmHooks
+	HooksICS4Wrapper ibchooks.ICS4Middleware
+
+	// make scoped keepers public for test purposes
+	ScopedIBCKeeper           capabilitykeeper.ScopedKeeper
+	ScopedTransferKeeper      capabilitykeeper.ScopedKeeper
+	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
+	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
+	ScopedICQKeeper           capabilitykeeper.ScopedKeeper
+
+	WasmKeeper       wasmkeeper.Keeper
+	scopedWasmKeeper capabilitykeeper.ScopedKeeper
+
+	// BuilderKeeper is the keeper that handles processing auction transactions
+	BuilderKeeper pobkeeper.Keeper
+}
+
+func NewTerraAppKeepers(
+	appCodec codec.Codec,
+	baseApp *baseapp.BaseApp,
+	cdc *codec.LegacyAmino,
+	appOpts servertypes.AppOptions,
+	wasmOpts []wasmkeeper.Option,
+) (keepers TerraAppKeepers) {
+	// Set keys KVStoreKey, TransientStoreKey, MemoryStoreKey
+	keepers.GenerateKeys()
+	keys := keepers.GetKVStoreKey()
+	tkeys := keepers.GetTransientStoreKey()
+
+	govModuleAddress := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+
+	keepers.ParamsKeeper = keepers.initParamsKeeper(
+		appCodec,
+		cdc,
+		keys[paramstypes.StoreKey],
+		tkeys[paramstypes.TStoreKey],
+	)
+
+	keepers.ConsensusParamsKeeper = consensusparamkeeper.NewKeeper(
+		appCodec,
+		keys[consensusparamtypes.StoreKey],
+		govModuleAddress,
+	)
+
+	// Create capability keeper and grant capabilities for the modules
+	keepers.CapabilityKeeper = capabilitykeeper.NewKeeper(
+		appCodec,
+		keys[capabilitytypes.StoreKey],
+		keepers.memKeys[capabilitytypes.MemStoreKey],
+	)
+	keepers.ScopedIBCKeeper = keepers.CapabilityKeeper.ScopeToModule(ibcexported.ModuleName)
+	keepers.ScopedTransferKeeper = keepers.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
+	keepers.ScopedICAControllerKeeper = keepers.CapabilityKeeper.ScopeToModule(icacontrollertypes.SubModuleName)
+	keepers.ScopedICAHostKeeper = keepers.CapabilityKeeper.ScopeToModule(icahosttypes.SubModuleName)
+	keepers.scopedWasmKeeper = keepers.CapabilityKeeper.ScopeToModule(icqtypes.ModuleName)
+	keepers.ScopedICQKeeper = keepers.CapabilityKeeper.ScopeToModule(wasmtypes.ModuleName)
+
+	keepers.AccountKeeper = authkeeper.NewAccountKeeper(
+		appCodec,
+		keys[authtypes.StoreKey],
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+		terraappconfig.AccountAddressPrefix,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.BankKeeper = custombankkeeper.NewBaseKeeper(
+		appCodec,
+		keys[banktypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.ModuleAccountAddrs(),
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.StakingKeeper = stakingkeeper.NewKeeper(
+		appCodec,
+		keys[stakingtypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.MintKeeper = mintkeeper.NewKeeper(
+		appCodec,
+		keys[minttypes.StoreKey],
+		keepers.StakingKeeper,
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.DistrKeeper = distrkeeper.NewKeeper(
+		appCodec,
+		keys[distrtypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.StakingKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.SlashingKeeper = slashingkeeper.NewKeeper(
+		appCodec,
+		cdc,
+		keys[slashingtypes.StoreKey],
+		keepers.StakingKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.CrisisKeeper = *crisiskeeper.NewKeeper(
+		appCodec,
+		keys[crisistypes.StoreKey],
+		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
+		keepers.BankKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	// Create upgrade keeper with skip upgrade height and homepath from appOpts
+	skipUpgradeHeights := map[int64]bool{}
+	for _, h := range cast.ToIntSlice(appOpts.Get(server.FlagUnsafeSkipUpgrades)) {
+		skipUpgradeHeights[int64(h)] = true
+	}
+	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
+	keepers.UpgradeKeeper = upgradekeeper.NewKeeper(
+		skipUpgradeHeights,
+		keys[upgradetypes.StoreKey],
+		appCodec,
+		homePath,
+		baseApp,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	keepers.AllianceKeeper = alliancekeeper.NewKeeper(
+		appCodec,
+		keys[alliancetypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.StakingKeeper,
+		keepers.DistrKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.BankKeeper.RegisterKeepers(keepers.AllianceKeeper, keepers.StakingKeeper)
+
+	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
+	keepers.StakingKeeper.SetHooks(
+		stakingtypes.NewMultiStakingHooks(
+			keepers.DistrKeeper.Hooks(),
+			keepers.SlashingKeeper.Hooks(),
+			keepers.AllianceKeeper.StakingHooks(),
+		),
+	)
+	keepers.TokenFactoryKeeper = tokenfactorykeeper.NewKeeper(
+		keys[tokenfactorytypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.DistrKeeper,
+		appCodec,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+	keepers.IBCKeeper = ibckeeper.NewKeeper(
+		appCodec,
+		keys[ibcexported.StoreKey],
+		keepers.GetSubspace(ibcexported.ModuleName),
+		keepers.StakingKeeper,
+		keepers.UpgradeKeeper,
+		keepers.ScopedIBCKeeper,
+	)
+	keepers.FeeGrantKeeper = feegrantkeeper.NewKeeper(
+		appCodec,
+		keys[feegrant.StoreKey],
+		keepers.AccountKeeper,
+	)
+	keepers.AuthzKeeper = authzkeeper.NewKeeper(
+		keys[authzkeeper.StoreKey],
+		appCodec,
+		baseApp.MsgServiceRouter(),
+		keepers.AccountKeeper,
+	)
+
+	// register the proposal types
+	govRouter := govtypesv1beta1.NewRouter()
+	govRouter.
+		AddRoute(govtypes.RouterKey, govtypesv1beta1.ProposalHandler).
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(keepers.ParamsKeeper)).
+		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(keepers.UpgradeKeeper)).
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(keepers.IBCKeeper.ClientKeeper)).
+		AddRoute(alliancetypes.RouterKey, alliance.NewAllianceProposalHandler(keepers.AllianceKeeper))
+
+	// Configure the hooks keeper
+	hooksKeeper := ibchookskeeper.NewKeeper(
+		keys[ibchookstypes.StoreKey],
+	)
+	keepers.IBCHooksKeeper = &hooksKeeper
+	wasmHooks := ibchooks.NewWasmHooks(&hooksKeeper, nil, terraappconfig.AccountAddressPrefix) // The contract keeper needs to be set later
+	keepers.Ics20WasmHooks = &wasmHooks
+	keepers.HooksICS4Wrapper = ibchooks.NewICS4Middleware(
+		keepers.IBCKeeper.ChannelKeeper,
+		keepers.Ics20WasmHooks,
+	)
+
+	keepers.TransferKeeper = ibctransferkeeper.NewKeeper(
+		appCodec,
+		keys[ibctransfertypes.StoreKey],
+		keepers.GetSubspace(ibctransfertypes.ModuleName),
+		keepers.HooksICS4Wrapper,
+		keepers.IBCKeeper.ChannelKeeper,
+		&keepers.IBCKeeper.PortKeeper,
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.ScopedTransferKeeper,
+	)
+	transferIBCModule := ibctransfer.NewIBCModule(keepers.TransferKeeper)
+
+	hooksTransferStack := ibchooks.NewIBCMiddleware(&transferIBCModule, &keepers.HooksICS4Wrapper)
+	keepers.RouterKeeper = *routerkeeper.NewKeeper(
+		appCodec,
+		keepers.keys[routertypes.StoreKey],
+		keepers.GetSubspace(routertypes.ModuleName),
+		keepers.TransferKeeper,
+		keepers.IBCKeeper.ChannelKeeper,
+		keepers.DistrKeeper,
+		keepers.BankKeeper,
+		keepers.IBCKeeper.ChannelKeeper,
+	)
+	keepers.TransferStack = router.NewIBCMiddleware(
+		hooksTransferStack,
+		&keepers.RouterKeeper,
+		5,
+		routerkeeper.DefaultForwardTransferPacketTimeoutTimestamp,
+		routerkeeper.DefaultRefundTransferPacketTimeoutTimestamp,
+	)
+	keepers.ICQKeeper = icqkeeper.NewKeeper(
+		appCodec,
+		keepers.keys[icqtypes.StoreKey],
+		keepers.GetSubspace(icqtypes.ModuleName),
+		keepers.IBCKeeper.ChannelKeeper,
+		keepers.IBCKeeper.ChannelKeeper,
+		&keepers.IBCKeeper.PortKeeper,
+		keepers.ScopedICQKeeper,
+		baseApp.GRPCQueryRouter(),
+	)
+	keepers.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
+		appCodec,
+		keys[ibcfeetypes.StoreKey],
+		keepers.IBCKeeper.ChannelKeeper,
+		keepers.IBCKeeper.ChannelKeeper,
+		&keepers.IBCKeeper.PortKeeper,
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+	)
+	keepers.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
+		appCodec,
+		keys[icacontrollertypes.StoreKey],
+		keepers.GetSubspace(icacontrollertypes.SubModuleName),
+		keepers.IBCFeeKeeper,
+		keepers.IBCKeeper.ChannelKeeper, &keepers.IBCKeeper.PortKeeper,
+		keepers.ScopedICAControllerKeeper,
+		baseApp.MsgServiceRouter(),
+	)
+	keepers.ICAHostKeeper = icahostkeeper.NewKeeper(
+		appCodec, keys[icahosttypes.StoreKey],
+		keepers.GetSubspace(icahosttypes.SubModuleName),
+		keepers.IBCFeeKeeper,
+		keepers.IBCKeeper.ChannelKeeper,
+		&keepers.IBCKeeper.PortKeeper,
+		keepers.AccountKeeper,
+		keepers.ScopedICAHostKeeper,
+		baseApp.MsgServiceRouter(),
+	)
+
+	var icaControllerStack porttypes.IBCModule
+	icaControllerStack = icacontroller.NewIBCMiddleware(icaControllerStack, keepers.ICAControllerKeeper)
+	icaControllerStack = ibcfee.NewIBCMiddleware(icaControllerStack, keepers.IBCFeeKeeper)
+
+	icaHostIBCModule := icahost.NewIBCModule(keepers.ICAHostKeeper)
+	icaHostStack := ibcfee.NewIBCMiddleware(icaHostIBCModule, keepers.IBCFeeKeeper)
+
+	// Create evidence Keeper for to register the IBC light client misbehaviour evidence route
+	evidenceKeeper := evidencekeeper.NewKeeper(
+		appCodec, keys[evidencetypes.StoreKey], keepers.StakingKeeper, keepers.SlashingKeeper,
+	)
+	// If evidence needs to be handled for the app, set routes in router here and seal
+	keepers.EvidenceKeeper = *evidenceKeeper
+
+	wasmDir := filepath.Join(homePath, "data")
+
+	// The last arguments can contain custom message handlers, and custom query handlers,
+	// if we want to allow any custom callbacks
+	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
+	if err != nil {
+		panic("error while reading wasm config: " + err.Error())
+	}
+	availableCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,token_factory"
+	keepers.WasmKeeper = wasmkeeper.NewKeeper(
+		appCodec,
+		keys[wasmtypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.StakingKeeper,
+		distrkeeper.NewQuerier(keepers.DistrKeeper),
+		keepers.IBCFeeKeeper, // ISC4 Wrapper: fee IBC middleware
+		keepers.IBCKeeper.ChannelKeeper,
+		&keepers.IBCKeeper.PortKeeper,
+		keepers.scopedWasmKeeper,
+		keepers.TransferKeeper,
+		baseApp.MsgServiceRouter(),
+		baseApp.GRPCQueryRouter(),
+		wasmDir,
+		wasmConfig,
+		availableCapabilities,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		wasmOpts...,
+	)
+
+	keepers.Ics20WasmHooks.ContractKeeper = &keepers.WasmKeeper
+	// Setup the contract keepers.WasmKeeper before the
+	// hook for the BankKeeper othrwise the WasmKeeper
+	// will be nil inside the hooks.
+	keepers.TokenFactoryKeeper.SetContractKeeper(keepers.WasmKeeper)
+	keepers.BankKeeper.SetHooks(
+		custombankkeeper.NewMultiBankHooks(
+			keepers.TokenFactoryKeeper.Hooks(),
+		),
+	)
+
+	// Create fee enabled wasm ibc Stack
+	var wasmStack porttypes.IBCModule
+	wasmStack = wasm.NewIBCHandler(keepers.WasmKeeper, keepers.IBCKeeper.ChannelKeeper, keepers.IBCFeeKeeper)
+	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, keepers.IBCFeeKeeper)
+
+	icqModule := icq.NewIBCModule(keepers.ICQKeeper)
+	// Create static IBC router, add transfer route, then set and seal it
+	ibcRouter := porttypes.NewRouter().
+		AddRoute(icacontrollertypes.SubModuleName, icaControllerStack).
+		AddRoute(icahosttypes.SubModuleName, icaHostStack).
+		AddRoute(ibctransfertypes.ModuleName, keepers.TransferStack).
+		AddRoute(wasmtypes.ModuleName, wasmStack).
+		AddRoute(icqtypes.ModuleName, icqModule)
+
+	keepers.IBCKeeper.SetRouter(ibcRouter)
+
+	govKeeper := govkeeper.NewKeeper(
+		appCodec,
+		keys[govtypes.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.StakingKeeper,
+		baseApp.MsgServiceRouter(),
+		govtypes.DefaultConfig(),
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	keepers.FeeShareKeeper = feesharekeeper.NewKeeper(
+		appCodec,
+		keys[feesharetypes.StoreKey],
+		keepers.BankKeeper,
+		keepers.WasmKeeper,
+		keepers.AccountKeeper,
+		authtypes.FeeCollectorName,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	// Set legacy router for backwards compatibility with gov v1beta1
+	govKeeper.SetLegacyRouter(govRouter)
+	keepers.GovKeeper = *govKeeper.SetHooks(
+		govtypes.NewMultiGovHooks(
+		// register the governance hooks
+		),
+	)
+
+	keepers.BuilderKeeper = pobkeeper.NewKeeper(
+		appCodec,
+		keys[pobtype.StoreKey],
+		keepers.AccountKeeper,
+		keepers.BankKeeper,
+		keepers.DistrKeeper,
+		keepers.StakingKeeper,
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+	)
+
+	return keepers
+}
+
+// ModuleAccountAddrs returns all the app's module account addresses.
+func (app *TerraAppKeepers) ModuleAccountAddrs() map[string]bool {
+	modAccAddrs := make(map[string]bool)
+
+	/* #nosec */
+	for acc := range maccPerms {
+		modAccAddrs[authtypes.NewModuleAddress(acc).String()] = true
+	}
+
+	delete(modAccAddrs, authtypes.NewModuleAddress(alliancetypes.ModuleName).String())
+
+	return modAccAddrs
+}
+
+// initParamsKeeper init params keeper and its subspaces
+func (app *TerraAppKeepers) initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey storetypes.StoreKey) paramskeeper.Keeper {
+	paramsKeeper := paramskeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
+
+	// Cosmo SDK Base Modules
+	paramsKeeper.Subspace(authtypes.ModuleName).WithKeyTable(authtypes.ParamKeyTable())
+	paramsKeeper.Subspace(banktypes.ModuleName).WithKeyTable(banktypes.ParamKeyTable())
+	paramsKeeper.Subspace(stakingtypes.ModuleName).WithKeyTable(stakingtypes.ParamKeyTable())
+	paramsKeeper.Subspace(minttypes.ModuleName).WithKeyTable(minttypes.ParamKeyTable())
+	paramsKeeper.Subspace(distrtypes.ModuleName).WithKeyTable(distrtypes.ParamKeyTable())
+	paramsKeeper.Subspace(slashingtypes.ModuleName).WithKeyTable(slashingtypes.ParamKeyTable())
+	paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govtypesv1.ParamKeyTable())
+	paramsKeeper.Subspace(crisistypes.ModuleName).WithKeyTable(crisistypes.ParamKeyTable())
+
+	// IBC Modules
+	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
+	paramsKeeper.Subspace(ibcexported.ModuleName)
+	paramsKeeper.Subspace(icahosttypes.SubModuleName)
+	paramsKeeper.Subspace(icacontrollertypes.SubModuleName)
+	paramsKeeper.Subspace(routertypes.ModuleName).WithKeyTable(routertypes.ParamKeyTable())
+	paramsKeeper.Subspace(icqtypes.ModuleName)
+
+	// Custom Modules
+	paramsKeeper.Subspace(wasmtypes.ModuleName).WithKeyTable(wasmtypes.ParamKeyTable())
+	paramsKeeper.Subspace(tokenfactorytypes.ModuleName).WithKeyTable(tokenfactorytypes.ParamKeyTable())
+	paramsKeeper.Subspace(feesharetypes.ModuleName).WithKeyTable(feesharetypes.ParamKeyTable())
+	paramsKeeper.Subspace(alliancetypes.ModuleName).WithKeyTable(alliancetypes.ParamKeyTable())
+
+	return paramsKeeper
+}
+
+// GetSubspace returns a param subspace for a given module name.
+func (appKeepers *TerraAppKeepers) GetSubspace(moduleName string) paramstypes.Subspace {
+	subspace, _ := appKeepers.ParamsKeeper.GetSubspace(moduleName)
+	return subspace
+}
+
+// GetMaccPerms returns a copy of the module account permissions
+func ModuleAccountAddrs() map[string]bool {
+	dupMaccPerms := make(map[string]bool)
+	for acc := range maccPerms {
+		dupMaccPerms[authtypes.NewModuleAddress(acc).String()] = true
+	}
+	delete(dupMaccPerms, authtypes.NewModuleAddress(alliancetypes.ModuleName).String())
+
+	return dupMaccPerms
+}

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -1,0 +1,103 @@
+package keepers
+
+import (
+
+	// #nosec G702
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	"github.com/cosmos/cosmos-sdk/x/feegrant"
+
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	routertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/types"
+
+	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
+	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
+	ibcfeetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
+	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7/types"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	tokenfactorytypes "github.com/terra-money/core/v2/x/tokenfactory/types"
+
+	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
+	feesharetypes "github.com/terra-money/core/v2/x/feeshare/types"
+
+	pobtype "github.com/skip-mev/pob/x/builder/types"
+
+	// unnamed import of statik for swagger UI support
+	_ "github.com/terra-money/core/v2/client/docs/statik"
+)
+
+func (keepers *TerraAppKeepers) GenerateKeys() {
+	keepers.keys = sdk.NewKVStoreKeys(
+		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
+		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
+		govtypes.StoreKey, paramstypes.StoreKey, ibcexported.StoreKey,
+		upgradetypes.StoreKey, evidencetypes.StoreKey, ibctransfertypes.StoreKey,
+		capabilitytypes.StoreKey, authzkeeper.StoreKey, feegrant.StoreKey,
+		icahosttypes.StoreKey, icacontrollertypes.StoreKey, routertypes.StoreKey,
+		consensusparamtypes.StoreKey, tokenfactorytypes.StoreKey, wasmtypes.StoreKey,
+		ibcfeetypes.StoreKey, ibchookstypes.StoreKey, crisistypes.StoreKey,
+		alliancetypes.StoreKey, feesharetypes.StoreKey, pobtype.StoreKey, icqtypes.StoreKey,
+	)
+
+	keepers.tkeys = sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
+	keepers.memKeys = sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
+}
+
+func (keepers *TerraAppKeepers) GetKVStoreKey() map[string]*storetypes.KVStoreKey {
+	return keepers.keys
+}
+
+func (keepers *TerraAppKeepers) GetTransientStoreKey() map[string]*storetypes.TransientStoreKey {
+	return keepers.tkeys
+}
+
+func (keepers *TerraAppKeepers) GetMemoryStoreKey() map[string]*storetypes.MemoryStoreKey {
+	return keepers.memKeys
+}
+
+// GetKey returns the KVStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (keepers *TerraAppKeepers) GetKey(storeKey string) *storetypes.KVStoreKey {
+	return keepers.keys[storeKey]
+}
+
+// GetTKey returns the TransientStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (keepers *TerraAppKeepers) GetTKey(storeKey string) *storetypes.TransientStoreKey {
+	return keepers.tkeys[storeKey]
+}
+
+// GetMemKey returns the MemStoreKey for the provided mem key.
+//
+// NOTE: This is solely used for testing purposes.
+func (keepers *TerraAppKeepers) GetMemKey(storeKey string) *storetypes.MemoryStoreKey {
+	return keepers.memKeys[storeKey]
+}

--- a/app/modules.go
+++ b/app/modules.go
@@ -1,0 +1,258 @@
+package app
+
+import (
+
+	// #nosec G702
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/cosmos-sdk/x/capability"
+	"github.com/cosmos/cosmos-sdk/x/crisis"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distr "github.com/cosmos/cosmos-sdk/x/distribution"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/evidence"
+	feegrantmodule "github.com/cosmos/cosmos-sdk/x/feegrant/module"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+
+	"github.com/cosmos/cosmos-sdk/x/gov"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/cosmos/cosmos-sdk/x/mint"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+
+	consensus "github.com/cosmos/cosmos-sdk/x/consensus"
+
+	"github.com/cosmos/cosmos-sdk/x/params"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/x/upgrade"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router"
+	routertypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/types"
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7/types"
+	ica "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts"
+	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
+	ibcfee "github.com/cosmos/ibc-go/v7/modules/apps/29-fee"
+	ibcfeetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
+	ibctransfer "github.com/cosmos/ibc-go/v7/modules/apps/transfer"
+	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	ibc "github.com/cosmos/ibc-go/v7/modules/core"
+	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
+	feesharetypes "github.com/terra-money/core/v2/x/feeshare/types"
+	tokenfactorytypes "github.com/terra-money/core/v2/x/tokenfactory/types"
+
+	icq "github.com/cosmos/ibc-apps/modules/async-icq/v7"
+
+	solomachine "github.com/cosmos/ibc-go/v7/modules/light-clients/06-solomachine"
+	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+
+	ibchooks "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+
+	"github.com/terra-money/core/v2/x/tokenfactory"
+
+	"github.com/terra-money/alliance/x/alliance"
+	terracustombank "github.com/terra-money/core/v2/custom/bank"
+	feeshare "github.com/terra-money/core/v2/x/feeshare"
+
+	pob "github.com/skip-mev/pob/x/builder"
+	pobtype "github.com/skip-mev/pob/x/builder/types"
+
+	"github.com/cosmos/cosmos-sdk/x/feegrant"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+	terrappsparams "github.com/terra-money/core/v2/app/params"
+)
+
+// ModuleBasics defines the module BasicManager is in charge of setting up basic,
+// non-dependant module elements, such as codec registration
+// and genesis verification.
+var ModuleBasics = module.NewBasicManager(
+	auth.AppModuleBasic{},
+	genutil.NewAppModuleBasic(genutiltypes.DefaultMessageValidator),
+	bank.AppModuleBasic{},
+	capability.AppModuleBasic{},
+	staking.AppModuleBasic{},
+	mint.AppModuleBasic{},
+	distr.AppModuleBasic{},
+	gov.NewAppModuleBasic(getGovProposalHandlers()),
+	params.AppModuleBasic{},
+	crisis.AppModuleBasic{},
+	slashing.AppModuleBasic{},
+	ibc.AppModuleBasic{},
+	ibctm.AppModuleBasic{},
+	solomachine.AppModuleBasic{},
+	feegrantmodule.AppModuleBasic{},
+	upgrade.AppModuleBasic{},
+	evidence.AppModuleBasic{},
+	ibctransfer.AppModuleBasic{},
+	vesting.AppModuleBasic{},
+	ica.AppModuleBasic{},
+	ibcfee.AppModuleBasic{},
+	router.AppModuleBasic{},
+	authzmodule.AppModuleBasic{},
+	tokenfactory.AppModuleBasic{},
+	ibchooks.AppModuleBasic{},
+	wasm.AppModuleBasic{},
+	consensus.AppModuleBasic{},
+	alliance.AppModuleBasic{},
+	feeshare.AppModuleBasic{},
+	pob.AppModuleBasic{},
+	icq.AppModuleBasic{},
+)
+
+// NOTE: Any module instantiated in the module manager that is later modified
+// must be passed by reference here.
+func appModules(app *TerraApp, encodingConfig terrappsparams.EncodingConfig, skipGenesisInvariants bool) []module.AppModule {
+	return []module.AppModule{
+		genutil.NewAppModule(
+			app.Keepers.AccountKeeper, app.Keepers.StakingKeeper, app.BaseApp.DeliverTx,
+			encodingConfig.TxConfig,
+		),
+		auth.NewAppModule(app.appCodec, app.Keepers.AccountKeeper, nil, app.GetSubspace(authtypes.ModuleName)),
+		vesting.NewAppModule(app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.DistrKeeper, app.Keepers.StakingKeeper),
+		terracustombank.NewAppModule(app.appCodec, app.Keepers.BankKeeper, app.Keepers.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
+		capability.NewAppModule(app.appCodec, *app.Keepers.CapabilityKeeper, false),
+		crisis.NewAppModule(&app.Keepers.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
+		feegrantmodule.NewAppModule(app.appCodec, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.FeeGrantKeeper, app.interfaceRegistry),
+		gov.NewAppModule(app.appCodec, &app.Keepers.GovKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.GetSubspace(govtypes.ModuleName)),
+		mint.NewAppModule(app.appCodec, app.Keepers.MintKeeper, app.Keepers.AccountKeeper, nil, app.GetSubspace(minttypes.ModuleName)),
+		slashing.NewAppModule(app.appCodec, app.Keepers.SlashingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper, app.GetSubspace(slashingtypes.ModuleName)),
+		distr.NewAppModule(app.appCodec, app.Keepers.DistrKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper, app.GetSubspace(distrtypes.ModuleName)),
+		staking.NewAppModule(app.appCodec, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.GetSubspace(stakingtypes.ModuleName)),
+		consensus.NewAppModule(app.appCodec, app.Keepers.ConsensusParamsKeeper),
+		upgrade.NewAppModule(app.Keepers.UpgradeKeeper),
+		evidence.NewAppModule(app.Keepers.EvidenceKeeper),
+		ibc.NewAppModule(app.Keepers.IBCKeeper),
+		params.NewAppModule(app.Keepers.ParamsKeeper),
+		authzmodule.NewAppModule(app.appCodec, app.Keepers.AuthzKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.interfaceRegistry),
+		ibctransfer.NewAppModule(app.Keepers.TransferKeeper),
+		ibcfee.NewAppModule(app.Keepers.IBCFeeKeeper),
+		ica.NewAppModule(&app.Keepers.ICAControllerKeeper, &app.Keepers.ICAHostKeeper),
+		router.NewAppModule(&app.Keepers.RouterKeeper),
+		wasm.NewAppModule(app.appCodec, &app.Keepers.WasmKeeper, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.MsgServiceRouter(), app.GetSubspace(wasmtypes.ModuleName)),
+		ibchooks.NewAppModule(app.Keepers.AccountKeeper),
+		tokenfactory.NewAppModule(app.Keepers.TokenFactoryKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.GetSubspace(tokenfactorytypes.ModuleName)),
+		alliance.NewAppModule(app.appCodec, app.Keepers.AllianceKeeper, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.interfaceRegistry, app.GetSubspace(alliancetypes.ModuleName)),
+		feeshare.NewAppModule(app.Keepers.FeeShareKeeper, app.Keepers.AccountKeeper, app.GetSubspace(feesharetypes.ModuleName)),
+		pob.NewAppModule(app.appCodec, app.Keepers.BuilderKeeper),
+		icq.NewAppModule(app.Keepers.ICQKeeper),
+	}
+}
+
+var initGenesisOrder = []string{
+	capabilitytypes.ModuleName,
+	authtypes.ModuleName,
+	banktypes.ModuleName,
+	distrtypes.ModuleName,
+	stakingtypes.ModuleName,
+	slashingtypes.ModuleName,
+	govtypes.ModuleName,
+	minttypes.ModuleName,
+	crisistypes.ModuleName,
+	genutiltypes.ModuleName,
+	evidencetypes.ModuleName,
+	authz.ModuleName,
+	paramstypes.ModuleName,
+	upgradetypes.ModuleName,
+	vestingtypes.ModuleName,
+	feegrant.ModuleName,
+	ibcexported.ModuleName,
+	ibctransfertypes.ModuleName,
+	icatypes.ModuleName,
+	ibcfeetypes.ModuleName,
+	routertypes.ModuleName,
+	tokenfactorytypes.ModuleName,
+	ibchookstypes.ModuleName,
+	wasmtypes.ModuleName,
+	alliancetypes.ModuleName,
+	feesharetypes.ModuleName,
+	consensusparamtypes.ModuleName,
+	icqtypes.ModuleName,
+	pobtype.ModuleName,
+}
+
+var beginBlockersOrder = []string{
+	upgradetypes.ModuleName,
+	capabilitytypes.ModuleName,
+	minttypes.ModuleName,
+	distrtypes.ModuleName,
+	slashingtypes.ModuleName,
+	evidencetypes.ModuleName,
+	stakingtypes.ModuleName,
+	authtypes.ModuleName,
+	banktypes.ModuleName,
+	govtypes.ModuleName,
+	crisistypes.ModuleName,
+	genutiltypes.ModuleName,
+	authz.ModuleName,
+	feegrant.ModuleName,
+	paramstypes.ModuleName,
+	vestingtypes.ModuleName,
+	// additional modules
+	ibcexported.ModuleName,
+	ibctransfertypes.ModuleName,
+	icatypes.ModuleName,
+	ibcfeetypes.ModuleName,
+	routertypes.ModuleName,
+	ibchookstypes.ModuleName,
+	wasmtypes.ModuleName,
+	tokenfactorytypes.ModuleName,
+	alliancetypes.ModuleName,
+	feesharetypes.ModuleName,
+	consensusparamtypes.ModuleName,
+	icqtypes.ModuleName,
+	pobtype.ModuleName,
+}
+
+var endBlockerOrder = []string{
+	crisistypes.ModuleName,
+	govtypes.ModuleName,
+	stakingtypes.ModuleName,
+	capabilitytypes.ModuleName,
+	authtypes.ModuleName,
+	banktypes.ModuleName,
+	distrtypes.ModuleName,
+	slashingtypes.ModuleName,
+	minttypes.ModuleName,
+	genutiltypes.ModuleName,
+	evidencetypes.ModuleName,
+	authz.ModuleName,
+	feegrant.ModuleName,
+	paramstypes.ModuleName,
+	upgradetypes.ModuleName,
+	vestingtypes.ModuleName,
+	// additional non simd modules
+	ibcexported.ModuleName,
+	ibctransfertypes.ModuleName,
+	icatypes.ModuleName,
+	ibcfeetypes.ModuleName,
+	routertypes.ModuleName,
+	ibchookstypes.ModuleName,
+	wasmtypes.ModuleName,
+	tokenfactorytypes.ModuleName,
+	alliancetypes.ModuleName,
+	feesharetypes.ModuleName,
+	consensusparamtypes.ModuleName,
+	icqtypes.ModuleName,
+	pobtype.ModuleName,
+}

--- a/app/simulation_test.go
+++ b/app/simulation_test.go
@@ -7,16 +7,12 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/libs/log"
 
-	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/require"
 	"github.com/terra-money/core/v2/app"
+	"github.com/terra-money/core/v2/app/keepers"
 	"github.com/terra-money/core/v2/app/wasmconfig"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/codec"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
 	simulationtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
@@ -24,19 +20,6 @@ import (
 
 func init() {
 	simcli.GetSimulatorFlags()
-}
-
-type terraApp interface {
-	app.TerraApp
-	GetBaseApp() *baseapp.BaseApp
-	AppCodec() codec.Codec
-	SimulationManager() *module.SimulationManager
-	ModuleAccountAddrs() map[string]bool
-	Name() string
-	LegacyAmino() *codec.LegacyAmino
-	BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock
-	EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock
-	InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain
 }
 
 // BenchmarkSimulation run the chain simulation
@@ -82,7 +65,7 @@ func BenchmarkSimulation(b *testing.B) {
 		simtestutil.AppStateFn(terraApp.AppCodec(), terraApp.SimulationManager(), terraApp.DefaultGenesis()),
 		simulationtypes.RandomAccounts,
 		simtestutil.SimulationOperations(terraApp, terraApp.AppCodec(), config),
-		terraApp.ModuleAccountAddrs(),
+		keepers.ModuleAccountAddrs(),
 		config,
 		terraApp.AppCodec(),
 	)

--- a/app/upgrade_handler.go
+++ b/app/upgrade_handler.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	consensusparamtypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibchookstypes "github.com/cosmos/ibc-apps/modules/ibc-hooks/v7/types"
+	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
+	ibcfeetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
+	pobtype "github.com/skip-mev/pob/x/builder/types"
+	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
+	terraappconfig "github.com/terra-money/core/v2/app/config"
+	v2_2_0 "github.com/terra-money/core/v2/app/upgrades/v2.2.0"
+	v2_3_0 "github.com/terra-money/core/v2/app/upgrades/v2.3.0"
+	v2_4 "github.com/terra-money/core/v2/app/upgrades/v2.4"
+	v2_5 "github.com/terra-money/core/v2/app/upgrades/v2.5"
+	v2_6 "github.com/terra-money/core/v2/app/upgrades/v2.6"
+	v2_7 "github.com/terra-money/core/v2/app/upgrades/v2.7"
+	feesharetypes "github.com/terra-money/core/v2/x/feeshare/types"
+	tokenfactorytypes "github.com/terra-money/core/v2/x/tokenfactory/types"
+
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+)
+
+// RegisterUpgradeHandlers returns upgrade handlers
+func (app *TerraApp) RegisterUpgradeHandlers() {
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_2_0,
+		v2_2_0.CreateUpgradeHandler(app.GetModuleManager(), app.GetConfigurator()),
+	)
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_3_0,
+		v2_3_0.CreateUpgradeHandler(app.GetModuleManager(), app.GetConfigurator(), app.Keepers.TokenFactoryKeeper),
+	)
+	// This is pisco only since an incorrect plan name was used for the upgrade
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_4_rc,
+		v2_4.CreateUpgradeHandler(app.GetModuleManager(), app.GetConfigurator()),
+	)
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_4,
+		v2_4.CreateUpgradeHandler(app.GetModuleManager(), app.GetConfigurator()),
+	)
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_5,
+		v2_5.CreateUpgradeHandler(app.GetModuleManager(),
+			app.GetConfigurator(),
+			app.GetAppCodec(),
+			app.Keepers.IBCKeeper.ClientKeeper,
+			app.Keepers.ParamsKeeper,
+			app.Keepers.ConsensusParamsKeeper,
+			app.Keepers.ICAControllerKeeper,
+			app.Keepers.BuilderKeeper,
+			app.Keepers.AccountKeeper,
+		),
+	)
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_6,
+		v2_6.CreateUpgradeHandler(app.GetModuleManager(),
+			app.GetConfigurator(),
+			app.GetAppCodec(),
+			app.Keepers.IBCKeeper.ClientKeeper,
+			app.Keepers.AccountKeeper,
+			app.Keepers.FeeShareKeeper,
+		),
+	)
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_7,
+		v2_7.CreateUpgradeHandler(
+			app.GetModuleManager(),
+			app.GetConfigurator(),
+			app.GetAppCodec(),
+			app.Keepers.ICQKeeper,
+		),
+	)
+}
+
+func (app *TerraApp) RegisterUpgradeStores() {
+	upgradeInfo, err := app.Keepers.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(err)
+	}
+
+	// Add stores for new modules
+	if upgradeInfo.Name == terraappconfig.Upgrade2_3_0 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{
+				icacontrollertypes.StoreKey,
+				tokenfactorytypes.StoreKey,
+				ibcfeetypes.StoreKey,
+				ibchookstypes.StoreKey,
+				alliancetypes.StoreKey,
+			},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	} else if upgradeInfo.Name == terraappconfig.Upgrade2_5 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{
+				consensusparamtypes.StoreKey,
+				crisistypes.StoreKey,
+				pobtype.StoreKey,
+			},
+			Deleted: []string{
+				// Module intertx removed in v2.5 because it was never used
+				// (https://github.com/cosmos/interchain-accounts-demo)
+				// The same functionalities are availablein the interchain-accounts
+				// module commands available in scripts/tests/ica/delegate.sh
+				"intertx",
+			},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	} else if upgradeInfo.Name == terraappconfig.Upgrade2_6 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{
+				feesharetypes.StoreKey,
+			},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	} else if upgradeInfo.Name == terraappconfig.Upgrade2_7 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{
+			Added: []string{
+				icqtypes.StoreKey,
+			},
+		}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+}

--- a/x/feeshare/keeper/genesis_test.go
+++ b/x/feeshare/keeper/genesis_test.go
@@ -86,14 +86,14 @@ func (suite *GenesisTestSuite) TestFeeShareInitGenesis() {
 
 			if tc.expPanic {
 				suite.Require().Panics(func() {
-					suite.App.FeeShareKeeper.InitGenesis(suite.Ctx, tc.genesis)
+					suite.App.Keepers.FeeShareKeeper.InitGenesis(suite.Ctx, tc.genesis)
 				})
 			} else {
 				suite.Require().NotPanics(func() {
-					suite.App.FeeShareKeeper.InitGenesis(suite.Ctx, tc.genesis)
+					suite.App.Keepers.FeeShareKeeper.InitGenesis(suite.Ctx, tc.genesis)
 				})
 
-				params := suite.App.FeeShareKeeper.GetParams(suite.Ctx)
+				params := suite.App.Keepers.FeeShareKeeper.GetParams(suite.Ctx)
 				suite.Require().Equal(tc.genesis.Params, params)
 			}
 		})

--- a/x/feeshare/keeper/grpc_query_test.go
+++ b/x/feeshare/keeper/grpc_query_test.go
@@ -37,7 +37,7 @@ func (s *IntegrationTestSuite) TestFeeShares() {
 
 		feeShares = append(feeShares, feeShare)
 
-		_, err := s.App.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
+		_, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
 		s.Require().NoError(err)
 	}
 
@@ -99,7 +99,7 @@ func (s *IntegrationTestSuite) TestFeeShare() {
 		DeployerAddress:   sender.String(),
 		WithdrawerAddress: withdrawer.String(),
 	}
-	_, err := s.App.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
+	_, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
 	s.Require().NoError(err)
 
 	req := &types.QueryFeeShareRequest{
@@ -131,7 +131,7 @@ func (s *IntegrationTestSuite) TestDeployerFeeShares() {
 			WithdrawerAddress: withdrawer.String(),
 		}
 
-		_, err := s.App.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
+		_, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
 		s.Require().NoError(err)
 	}
 
@@ -195,7 +195,7 @@ func (s *IntegrationTestSuite) TestWithdrawerFeeShares() {
 			WithdrawerAddress: withdrawer.String(),
 		}
 
-		_, err := s.App.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
+		_, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(s.Ctx, msg)
 		s.Require().NoError(err)
 	}
 

--- a/x/feeshare/keeper/msg_server_test.go
+++ b/x/feeshare/keeper/msg_server_test.go
@@ -32,7 +32,7 @@ func (s *IntegrationTestSuite) StoreCode() {
 	expHash := sha256.Sum256(wasmContract)
 	s.Require().Equal(expHash[:], result.Checksum)
 	// and
-	info := s.App.WasmKeeper.GetCodeInfo(s.Ctx, 1)
+	info := s.App.Keepers.WasmKeeper.GetCodeInfo(s.Ctx, 1)
 	s.Require().NotNil(info)
 	s.Require().Equal(expHash[:], info.CodeHash)
 	s.Require().Equal(sender.String(), info.Creator)
@@ -57,7 +57,7 @@ func (s *IntegrationTestSuite) InstantiateContract(sender string, admin string) 
 	s.Require().NoError(err)
 	var result wasmtypes.MsgInstantiateContractResponse
 	s.Require().NoError(s.App.AppCodec().Unmarshal(resp.Data, &result))
-	contractInfo := s.App.WasmKeeper.GetContractInfo(s.Ctx, sdk.MustAccAddressFromBech32(result.Address))
+	contractInfo := s.App.Keepers.WasmKeeper.GetContractInfo(s.Ctx, sdk.MustAccAddressFromBech32(result.Address))
 	s.Require().Equal(contractInfo.CodeID, uint64(1))
 	s.Require().Equal(contractInfo.Admin, admin)
 	s.Require().Equal(contractInfo.Creator, sender)
@@ -101,10 +101,10 @@ func (s *IntegrationTestSuite) TestGetContractAdminOrCreatorAddress() {
 		tc := tc
 		s.Run(tc.desc, func() {
 			if !tc.shouldErr {
-				_, err := s.App.FeeShareKeeper.GetContractAdminOrCreatorAddress(s.Ctx, sdk.MustAccAddressFromBech32(tc.contractAddress), tc.deployerAddress)
+				_, err := s.App.Keepers.FeeShareKeeper.GetContractAdminOrCreatorAddress(s.Ctx, sdk.MustAccAddressFromBech32(tc.contractAddress), tc.deployerAddress)
 				s.Require().NoError(err)
 			} else {
-				_, err := s.App.FeeShareKeeper.GetContractAdminOrCreatorAddress(s.Ctx, sdk.MustAccAddressFromBech32(tc.contractAddress), tc.deployerAddress)
+				_, err := s.App.Keepers.FeeShareKeeper.GetContractAdminOrCreatorAddress(s.Ctx, sdk.MustAccAddressFromBech32(tc.contractAddress), tc.deployerAddress)
 				s.Require().Error(err)
 			}
 		})
@@ -115,7 +115,7 @@ func (s *IntegrationTestSuite) TestRegisterFeeShare() {
 	s.Setup()
 	sender := s.TestAccs[0]
 
-	gov := s.App.AccountKeeper.GetModuleAddress(govtypes.ModuleName).String()
+	gov := s.App.Keepers.AccountKeeper.GetModuleAddress(govtypes.ModuleName).String()
 	govContract := s.InstantiateContract(sender.String(), gov)
 
 	contractAddress := s.InstantiateContract(sender.String(), "")
@@ -225,11 +225,11 @@ func (s *IntegrationTestSuite) TestRegisterFeeShare() {
 	} {
 		s.Run(tc.desc, func() {
 			if !tc.shouldErr {
-				resp, err := s.App.FeeShareKeeper.RegisterFeeShare(s.Ctx, tc.msg)
+				resp, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(s.Ctx, tc.msg)
 				s.Require().NoError(err)
 				s.Require().Equal(resp, tc.resp)
 			} else {
-				resp, err := s.App.FeeShareKeeper.RegisterFeeShare(s.Ctx, tc.msg)
+				resp, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(s.Ctx, tc.msg)
 				s.Require().Error(err)
 				s.Require().Nil(resp)
 			}
@@ -254,7 +254,7 @@ func (s *IntegrationTestSuite) TestUpdateFeeShare() {
 		DeployerAddress:   sender.String(),
 		WithdrawerAddress: withdrawer.String(),
 	}
-	_, err := s.App.FeeShareKeeper.RegisterFeeShare(goCtx, msg)
+	_, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(goCtx, msg)
 	s.Require().NoError(err)
 	_, _, newWithdrawer := testdata.KeyTestPubAddr()
 	s.Require().NotEqual(withdrawer, newWithdrawer)
@@ -320,10 +320,10 @@ func (s *IntegrationTestSuite) TestUpdateFeeShare() {
 		s.Run(tc.desc, func() {
 			goCtx := sdk.WrapSDKContext(s.Ctx)
 			if !tc.shouldErr {
-				_, err := s.App.FeeShareKeeper.UpdateFeeShare(goCtx, tc.msg)
+				_, err := s.App.Keepers.FeeShareKeeper.UpdateFeeShare(goCtx, tc.msg)
 				s.Require().NoError(err)
 			} else {
-				resp, err := s.App.FeeShareKeeper.UpdateFeeShare(goCtx, tc.msg)
+				resp, err := s.App.Keepers.FeeShareKeeper.UpdateFeeShare(goCtx, tc.msg)
 				s.Require().Error(err)
 				s.Require().Nil(resp)
 			}
@@ -345,7 +345,7 @@ func (s *IntegrationTestSuite) TestCancelFeeShare() {
 		DeployerAddress:   sender.String(),
 		WithdrawerAddress: withdrawer.String(),
 	}
-	_, err := s.App.FeeShareKeeper.RegisterFeeShare(goCtx, msg)
+	_, err := s.App.Keepers.FeeShareKeeper.RegisterFeeShare(goCtx, msg)
 	s.Require().NoError(err)
 
 	for _, tc := range []struct {
@@ -386,11 +386,11 @@ func (s *IntegrationTestSuite) TestCancelFeeShare() {
 		s.Run(tc.desc, func() {
 			goCtx := sdk.WrapSDKContext(s.Ctx)
 			if !tc.shouldErr {
-				resp, err := s.App.FeeShareKeeper.CancelFeeShare(goCtx, tc.msg)
+				resp, err := s.App.Keepers.FeeShareKeeper.CancelFeeShare(goCtx, tc.msg)
 				s.Require().NoError(err)
 				s.Require().Equal(resp, tc.resp)
 			} else {
-				resp, err := s.App.FeeShareKeeper.CancelFeeShare(goCtx, tc.msg)
+				resp, err := s.App.Keepers.FeeShareKeeper.CancelFeeShare(goCtx, tc.msg)
 				s.Require().Error(err)
 				s.Require().Equal(resp, tc.resp)
 			}

--- a/x/tokenfactory/bindings/custom_msg_test.go
+++ b/x/tokenfactory/bindings/custom_msg_test.go
@@ -241,7 +241,7 @@ func TestMintMsg(t *testing.T) {
 	fundAccount(t, ctx, app, reflect, reflectAmount)
 
 	// lucky was broke
-	balances := app.BankKeeper.GetAllBalances(ctx, lucky)
+	balances := app.Keepers.BankKeeper.GetAllBalances(ctx, lucky)
 	require.Empty(t, balances)
 
 	// Create denom for minting
@@ -262,7 +262,7 @@ func TestMintMsg(t *testing.T) {
 	err = executeCustom(t, ctx, app, reflect, lucky, msg, sdk.Coin{})
 	require.NoError(t, err)
 
-	balances = app.BankKeeper.GetAllBalances(ctx, lucky)
+	balances = app.Keepers.BankKeeper.GetAllBalances(ctx, lucky)
 	require.Len(t, balances, 1)
 	coin := balances[0]
 	require.Equal(t, amount, coin.Amount)
@@ -285,7 +285,7 @@ func TestMintMsg(t *testing.T) {
 	err = executeCustom(t, ctx, app, reflect, lucky, msg, sdk.Coin{})
 	require.NoError(t, err)
 
-	balances = app.BankKeeper.GetAllBalances(ctx, lucky)
+	balances = app.Keepers.BankKeeper.GetAllBalances(ctx, lucky)
 	require.Len(t, balances, 1)
 	coin = balances[0]
 	require.Equal(t, amount.MulRaw(2), coin.Amount)
@@ -322,7 +322,7 @@ func TestMintMsg(t *testing.T) {
 	err = executeCustom(t, ctx, app, reflect, lucky, msg, sdk.Coin{})
 	require.NoError(t, err)
 
-	balances = app.BankKeeper.GetAllBalances(ctx, lucky)
+	balances = app.Keepers.BankKeeper.GetAllBalances(ctx, lucky)
 	require.Len(t, balances, 2)
 	coin = balances[0]
 	require.Equal(t, amount, coin.Amount)
@@ -373,7 +373,7 @@ func TestBurnMsg(t *testing.T) {
 	fundAccount(t, ctx, app, reflect, reflectAmount)
 
 	// lucky was broke
-	balances := app.BankKeeper.GetAllBalances(ctx, lucky)
+	balances := app.Keepers.BankKeeper.GetAllBalances(ctx, lucky)
 	require.Empty(t, balances)
 
 	// Create denom for minting
@@ -405,8 +405,8 @@ func TestBurnMsg(t *testing.T) {
 	require.Error(t, err)
 
 	// lucky needs to send balance to reflect contract to burn it
-	luckyBalance := app.BankKeeper.GetAllBalances(ctx, lucky)
-	err = app.BankKeeper.SendCoins(ctx, lucky, reflect, luckyBalance)
+	luckyBalance := app.Keepers.BankKeeper.GetAllBalances(ctx, lucky)
+	err = app.Keepers.BankKeeper.SendCoins(ctx, lucky, reflect, luckyBalance)
 	require.NoError(t, err)
 
 	msg = bindings.TokenMsg{BurnTokens: &bindings.BurnTokens{
@@ -455,7 +455,7 @@ func executeCustom(t *testing.T, ctx sdk.Context, app *app.TerraApp, contract sd
 		coins = sdk.Coins{funds}
 	}
 
-	contractKeeper := keeper.NewDefaultPermissionKeeper(app.WasmKeeper)
+	contractKeeper := keeper.NewDefaultPermissionKeeper(app.Keepers.WasmKeeper)
 	_, err = contractKeeper.Execute(ctx, contract, sender, reflectBz, coins)
 	return err
 }

--- a/x/tokenfactory/bindings/custom_query_test.go
+++ b/x/tokenfactory/bindings/custom_query_test.go
@@ -159,7 +159,7 @@ func queryCustom(t *testing.T, ctx sdk.Context, app *app.TerraApp, contract sdk.
 		return err
 	}
 
-	resBz, err := app.WasmKeeper.QuerySmart(ctx, contract, queryBz)
+	resBz, err := app.Keepers.WasmKeeper.QuerySmart(ctx, contract, queryBz)
 	if err != nil {
 		return err
 	}

--- a/x/tokenfactory/bindings/helpers_test.go
+++ b/x/tokenfactory/bindings/helpers_test.go
@@ -48,19 +48,19 @@ func CreateTestInput() (*app.TerraApp, sdk.Context) {
 		wasmconfig.DefaultConfig(),
 	)
 	ctx := terraApp.BaseApp.NewContext(true, tmproto.Header{Height: 1, ChainID: "phoenix-1", Time: time.Now()})
-	err := terraApp.WasmKeeper.SetParams(ctx, wasmtypes.DefaultParams())
+	err := terraApp.Keepers.WasmKeeper.SetParams(ctx, wasmtypes.DefaultParams())
 	if err != nil {
 		panic(err)
 	}
-	terraApp.BankKeeper.SetParams(ctx, banktypes.NewParams(true))
+	terraApp.Keepers.BankKeeper.SetParams(ctx, banktypes.NewParams(true))
 	if err != nil {
 		panic(err)
 	}
-	terraApp.TokenFactoryKeeper.SetParams(ctx, tokenfactorytypes.DefaultParams())
+	terraApp.Keepers.TokenFactoryKeeper.SetParams(ctx, tokenfactorytypes.DefaultParams())
 	if err != nil {
 		panic(err)
 	}
-	terraApp.DistrKeeper.SetFeePool(ctx, distrtypes.InitialFeePool())
+	terraApp.Keepers.DistrKeeper.SetFeePool(ctx, distrtypes.InitialFeePool())
 	if err != nil {
 		panic(err)
 	}
@@ -93,7 +93,7 @@ func storeReflectCode(t *testing.T, ctx sdk.Context, app *app.TerraApp, addr sdk
 	wasmCode, err := os.ReadFile("./testdata/token_reflect.wasm")
 	require.NoError(t, err)
 
-	contractKeeper := keeper.NewDefaultPermissionKeeper(app.WasmKeeper)
+	contractKeeper := keeper.NewDefaultPermissionKeeper(app.Keepers.WasmKeeper)
 	codeID, _, err := contractKeeper.Create(ctx, addr, wasmCode, &wasmtypes.AccessConfig{Permission: wasmtypes.AccessTypeEverybody})
 	require.NoError(t, err)
 
@@ -103,7 +103,7 @@ func storeReflectCode(t *testing.T, ctx sdk.Context, app *app.TerraApp, addr sdk
 func instantiateReflectContract(t *testing.T, ctx sdk.Context, app *app.TerraApp, funder sdk.AccAddress) sdk.AccAddress {
 	t.Helper()
 	initMsgBz := []byte("{}")
-	contractKeeper := keeper.NewDefaultPermissionKeeper(app.WasmKeeper)
+	contractKeeper := keeper.NewDefaultPermissionKeeper(app.Keepers.WasmKeeper)
 	codeID := uint64(1)
 	addr, _, err := contractKeeper.Instantiate(ctx, codeID, funder, funder, initMsgBz, "demo contract", nil)
 	require.NoError(t, err)
@@ -113,9 +113,9 @@ func instantiateReflectContract(t *testing.T, ctx sdk.Context, app *app.TerraApp
 
 func fundAccount(t *testing.T, ctx sdk.Context, app *app.TerraApp, addr sdk.AccAddress, coins sdk.Coins) {
 	t.Helper()
-	err := app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, coins)
+	err := app.Keepers.BankKeeper.MintCoins(ctx, minttypes.ModuleName, coins)
 	require.NoError(t, err)
-	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr, coins)
+	err = app.Keepers.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr, coins)
 	require.NoError(t, err)
 }
 
@@ -125,7 +125,7 @@ func SetupCustomApp(t *testing.T, addr sdk.AccAddress) (*app.TerraApp, sdk.Conte
 
 	storeReflectCode(t, ctx, app, addr)
 
-	cInfo := app.WasmKeeper.GetCodeInfo(ctx, 1)
+	cInfo := app.Keepers.WasmKeeper.GetCodeInfo(ctx, 1)
 	require.NotNil(t, cInfo)
 
 	return app, ctx

--- a/x/tokenfactory/bindings/wasm.go
+++ b/x/tokenfactory/bindings/wasm.go
@@ -2,12 +2,9 @@ package bindings
 
 import (
 	"github.com/CosmWasm/wasmd/x/wasm"
-
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-
-	tokenfactorykeeper "github.com/terra-money/core/v2/x/tokenfactory/keeper"
-
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	tokenfactorykeeper "github.com/terra-money/core/v2/x/tokenfactory/keeper"
 )
 
 func RegisterCustomPlugins(

--- a/x/tokenfactory/client/cli/query_test.go
+++ b/x/tokenfactory/client/cli/query_test.go
@@ -25,7 +25,7 @@ func (s *QueryTestSuite) TestQueriesNeverAlterState() {
 	fundAccsAmount := sdk.NewCoins(sdk.NewCoin(config.BondDenom, math.NewInt(1_000_000_000)))
 	s.FundAcc(s.TestAccs[0], fundAccsAmount)
 	// create new token
-	_, err := s.App.TokenFactoryKeeper.CreateDenom(s.Ctx, s.TestAccs[0].String(), "tokenfactory")
+	_, err := s.App.Keepers.TokenFactoryKeeper.CreateDenom(s.Ctx, s.TestAccs[0].String(), "tokenfactory")
 	s.Require().NoError(err)
 
 	testCases := []struct {

--- a/x/tokenfactory/keeper/before_send_test.go
+++ b/x/tokenfactory/keeper/before_send_test.go
@@ -173,7 +173,7 @@ func (s *KeeperTestSuite) TestInfiniteTrackBeforeSend() {
 			}
 
 			// send the mint module tokenToSend
-			if err := s.App.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, tokenToSend); err != nil {
+			if err := s.App.Keepers.BankKeeper.MintCoins(s.Ctx, minttypes.ModuleName, tokenToSend); err != nil {
 				s.Require().NoError(err)
 			}
 
@@ -186,12 +186,12 @@ func (s *KeeperTestSuite) TestInfiniteTrackBeforeSend() {
 			s.Require().NoError(err, "test: %v", tc.name)
 
 			// track before send suppresses in any case, thus we expect no error
-			err = s.App.BankKeeper.SendCoinsFromModuleToModule(s.Ctx, "mint", "distribution", tokenToSend)
+			err = s.App.Keepers.BankKeeper.SendCoinsFromModuleToModule(s.Ctx, "mint", "distribution", tokenToSend)
 			s.Require().NoError(err)
 
 			// send should happen regardless of trackBeforeSend results
-			distributionModuleAddress := s.App.AccountKeeper.GetModuleAddress("distribution")
-			distributionModuleBalances := s.App.BankKeeper.GetAllBalances(s.Ctx, distributionModuleAddress)
+			distributionModuleAddress := s.App.Keepers.AccountKeeper.GetModuleAddress("distribution")
+			distributionModuleBalances := s.App.Keepers.BankKeeper.GetAllBalances(s.Ctx, distributionModuleAddress)
 			s.Require().True(distributionModuleBalances[0].IsEqual(tokenToSend[0]))
 		})
 	}
@@ -225,7 +225,7 @@ func (s *KeeperTestSuite) TestCoinsFromSDK() {
 
 // Test get before send hook with no hook set
 func (s *KeeperTestSuite) TestGetBeforeSendHook() {
-	res := s.App.TokenFactoryKeeper.GetBeforeSendHook(s.Ctx, "foo")
+	res := s.App.Keepers.TokenFactoryKeeper.GetBeforeSendHook(s.Ctx, "foo")
 
 	expected := ""
 

--- a/x/tokenfactory/keeper/createdenom_test.go
+++ b/x/tokenfactory/keeper/createdenom_test.go
@@ -12,16 +12,16 @@ import (
 
 func (s *KeeperTestSuite) TestMsgCreateDenom() {
 	var (
-		tokenFactoryKeeper = s.App.TokenFactoryKeeper
-		bankKeeper         = s.App.BankKeeper
+		tokenFactoryKeeper = s.App.Keepers.TokenFactoryKeeper
+		bankKeeper         = s.App.Keepers.BankKeeper
 		denomCreationFee   = sdk.NewCoins(sdk.NewCoin("uluna", sdk.NewInt(1000000)))
 	)
 
 	// Set the denom creation fee. It is currently turned off in favor
 	// of gas charge by default.
-	params := s.App.TokenFactoryKeeper.GetParams(s.Ctx)
+	params := s.App.Keepers.TokenFactoryKeeper.GetParams(s.Ctx)
 	params.DenomCreationFee = denomCreationFee
-	s.App.TokenFactoryKeeper.SetParams(s.Ctx, params)
+	s.App.Keepers.TokenFactoryKeeper.SetParams(s.Ctx, params)
 
 	// Fund denom creation fee for every execution of MsgCreateDenom.
 	s.FundAcc(s.TestAccs[0], denomCreationFee)
@@ -133,8 +133,8 @@ func (s *KeeperTestSuite) TestCreateDenom() {
 			if tc.setup != nil {
 				tc.setup()
 			}
-			tokenFactoryKeeper := s.App.TokenFactoryKeeper
-			bankKeeper := s.App.BankKeeper
+			tokenFactoryKeeper := s.App.Keepers.TokenFactoryKeeper
+			bankKeeper := s.App.Keepers.BankKeeper
 			// Set denom creation fee in params
 			s.FundAcc(s.TestAccs[0], defaultDenomCreationFee.DenomCreationFee)
 			tokenFactoryKeeper.SetParams(s.Ctx, tc.denomCreationFee)
@@ -221,7 +221,7 @@ func (s *KeeperTestSuite) TestGasConsume() {
 		s.SetupTest()
 		s.Run(fmt.Sprintf("Case %s", tc.desc), func() {
 			// set params with the gas consume amount
-			s.App.TokenFactoryKeeper.SetParams(s.Ctx, types.NewParams(nil, tc.gasConsume))
+			s.App.Keepers.TokenFactoryKeeper.SetParams(s.Ctx, types.NewParams(nil, tc.gasConsume))
 
 			// amount of gas consumed prior to the denom creation
 			gasConsumedBefore := s.Ctx.GasMeter().GasConsumed()

--- a/x/tokenfactory/keeper/genesis_test.go
+++ b/x/tokenfactory/keeper/genesis_test.go
@@ -37,31 +37,31 @@ func (s *KeeperTestSuite) TestGenesis() {
 	for i, denom := range genesisState.FactoryDenoms {
 		// hacky, sets bank metadata to exist if i != 0, to cover both cases.
 		if i != 0 {
-			app.BankKeeper.SetDenomMetaData(s.Ctx, banktypes.Metadata{Base: denom.GetDenom(), Display: "test"})
+			app.Keepers.BankKeeper.SetDenomMetaData(s.Ctx, banktypes.Metadata{Base: denom.GetDenom(), Display: "test"})
 		}
 	}
 
 	// check before initGenesis that the module account is nil
-	tokenfactoryModuleAccount := app.AccountKeeper.GetAccount(s.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
+	tokenfactoryModuleAccount := app.Keepers.AccountKeeper.GetAccount(s.Ctx, app.Keepers.AccountKeeper.GetModuleAddress(types.ModuleName))
 	s.Require().Nil(tokenfactoryModuleAccount)
 
-	app.TokenFactoryKeeper.SetParams(s.Ctx, types.Params{DenomCreationFee: sdk.Coins{sdk.NewInt64Coin("uosmo", 100)}})
-	app.TokenFactoryKeeper.InitGenesis(s.Ctx, genesisState)
+	app.Keepers.TokenFactoryKeeper.SetParams(s.Ctx, types.Params{DenomCreationFee: sdk.Coins{sdk.NewInt64Coin("uosmo", 100)}})
+	app.Keepers.TokenFactoryKeeper.InitGenesis(s.Ctx, genesisState)
 
 	// check that the module account is now initialized
-	tokenfactoryModuleAccount = app.AccountKeeper.GetAccount(s.Ctx, app.AccountKeeper.GetModuleAddress(types.ModuleName))
+	tokenfactoryModuleAccount = app.Keepers.AccountKeeper.GetAccount(s.Ctx, app.Keepers.AccountKeeper.GetModuleAddress(types.ModuleName))
 	s.Require().NotNil(tokenfactoryModuleAccount)
 
-	exportedGenesis := app.TokenFactoryKeeper.ExportGenesis(s.Ctx)
+	exportedGenesis := app.Keepers.TokenFactoryKeeper.ExportGenesis(s.Ctx)
 	s.Require().NotNil(exportedGenesis)
 	s.Require().Equal(genesisState, *exportedGenesis)
 
-	app.BankKeeper.SetParams(s.Ctx, banktypes.DefaultParams())
-	app.BankKeeper.InitGenesis(s.Ctx, app.BankKeeper.ExportGenesis(s.Ctx))
+	app.Keepers.BankKeeper.SetParams(s.Ctx, banktypes.DefaultParams())
+	app.Keepers.BankKeeper.InitGenesis(s.Ctx, app.Keepers.BankKeeper.ExportGenesis(s.Ctx))
 	for i, denom := range genesisState.FactoryDenoms {
 		// hacky, check whether bank metadata is not replaced if i != 0, to cover both cases.
 		if i != 0 {
-			metadata, found := app.BankKeeper.GetDenomMetaData(s.Ctx, denom.GetDenom())
+			metadata, found := app.Keepers.BankKeeper.GetDenomMetaData(s.Ctx, denom.GetDenom())
 			s.Require().True(found)
 			s.Require().Equal(metadata, banktypes.Metadata{Base: denom.GetDenom(), Display: "test"})
 		}

--- a/x/tokenfactory/keeper/grpc_query_test.go
+++ b/x/tokenfactory/keeper/grpc_query_test.go
@@ -3,19 +3,19 @@ package keeper_test
 import "github.com/terra-money/core/v2/x/tokenfactory/types"
 
 func (s *KeeperTestSuite) TestQueryParams() {
-	params, err := s.App.TokenFactoryKeeper.Params(s.Ctx, &types.QueryParamsRequest{})
+	params, err := s.App.Keepers.TokenFactoryKeeper.Params(s.Ctx, &types.QueryParamsRequest{})
 
 	s.Require().NoError(err)
 
 	expected := types.QueryParamsResponse{
-		Params: s.App.TokenFactoryKeeper.GetParams(s.Ctx),
+		Params: s.App.Keepers.TokenFactoryKeeper.GetParams(s.Ctx),
 	}
 	s.Require().Equal(&expected, params)
 
 }
 
 func (s *KeeperTestSuite) TestQueryBeforeSendHookEmptyAddress() {
-	res, err := s.App.TokenFactoryKeeper.BeforeSendHookAddress(s.Ctx, &types.QueryBeforeSendHookAddressRequest{})
+	res, err := s.App.Keepers.TokenFactoryKeeper.BeforeSendHookAddress(s.Ctx, &types.QueryBeforeSendHookAddressRequest{})
 
 	s.Require().NoError(err)
 
@@ -27,7 +27,7 @@ func (s *KeeperTestSuite) TestQueryBeforeSendHookEmptyAddress() {
 }
 
 func (s *KeeperTestSuite) TestQueryBeforeSendHookNonRegisteredAddress() {
-	res, err := s.App.TokenFactoryKeeper.BeforeSendHookAddress(s.Ctx, &types.QueryBeforeSendHookAddressRequest{
+	res, err := s.App.Keepers.TokenFactoryKeeper.BeforeSendHookAddress(s.Ctx, &types.QueryBeforeSendHookAddressRequest{
 		Denom: "bitcoin",
 	})
 	s.Require().NoError(err)

--- a/x/tokenfactory/keeper/keeper_test.go
+++ b/x/tokenfactory/keeper/keeper_test.go
@@ -33,26 +33,26 @@ func TestKeeperTestSuite(t *testing.T) {
 
 func (s *KeeperTestSuite) SetupTest() {
 	s.Setup()
-	s.contractKeeper = wasmkeeper.NewGovPermissionKeeper(s.App.WasmKeeper)
+	s.contractKeeper = wasmkeeper.NewGovPermissionKeeper(s.App.Keepers.WasmKeeper)
 	s.queryClient = types.NewQueryClient(s.QueryHelper)
-	s.msgServer = keeper.NewMsgServerImpl(s.App.TokenFactoryKeeper)
-	s.bankMsgServer = bankkeeper.NewMsgServerImpl(s.App.BankKeeper)
+	s.msgServer = keeper.NewMsgServerImpl(s.App.Keepers.TokenFactoryKeeper)
+	s.bankMsgServer = bankkeeper.NewMsgServerImpl(s.App.Keepers.BankKeeper)
 }
 
 func (s *KeeperTestSuite) TestCreateModuleAccount() {
 	// setup new next account number
-	nextAccountNumber := s.App.AccountKeeper.NextAccountNumber(s.Ctx)
+	nextAccountNumber := s.App.Keepers.AccountKeeper.NextAccountNumber(s.Ctx)
 
 	// ensure module account was removed
 	s.Ctx = s.App.NewContext(true, tmproto.Header{Time: time.Now()})
-	tokenfactoryModuleAccount := s.App.AccountKeeper.GetAccount(s.Ctx, s.App.AccountKeeper.GetModuleAddress(types.ModuleName))
+	tokenfactoryModuleAccount := s.App.Keepers.AccountKeeper.GetAccount(s.Ctx, s.App.Keepers.AccountKeeper.GetModuleAddress(types.ModuleName))
 	s.Require().Nil(tokenfactoryModuleAccount)
 
 	// create module account
-	s.App.TokenFactoryKeeper.CreateModuleAccount(s.Ctx)
+	s.App.Keepers.TokenFactoryKeeper.CreateModuleAccount(s.Ctx)
 
 	// check that the module account is now initialized
-	tokenfactoryModuleAccount = s.App.AccountKeeper.GetAccount(s.Ctx, s.App.AccountKeeper.GetModuleAddress(types.ModuleName))
+	tokenfactoryModuleAccount = s.App.Keepers.AccountKeeper.GetAccount(s.Ctx, s.App.Keepers.AccountKeeper.GetModuleAddress(types.ModuleName))
 	s.Require().NotNil(tokenfactoryModuleAccount)
 
 	// check that the account number of the module account is now initialized correctly


### PR DESCRIPTION
This pull request move Keepers, AppModules and AppUpgrade handlers to their own files that way app.go is more legible 