### PR TITLE
feat: enable cosmwasm 1.4

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -452,7 +452,7 @@ func NewTerraAppKeepers(
 	if err != nil {
 		panic("error while reading wasm config: " + err.Error())
 	}
-	availableCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,token_factory"
+	availableCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,token_factory"
 	keepers.WasmKeeper = wasmkeeper.NewKeeper(
 		appCodec,
 		keys[wasmtypes.StoreKey],


### PR DESCRIPTION
With release 2.6 of core Wasmd was upgraded to the latest version including Wasmvm 1.4. 
This upgrade will enable all the new features. The choice to do it progressively is to make sure everything's still compatible before enabling the new features (in case a rollback is needed).