### PR TITLE
docs(v2.8): change README.md changelog URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
     <br />
     <br />
     <a href="https://codecov.io/gh/terra-money/core">
-        <img src="https://codecov.io/gh/terra-money/core/branch/main/graph/badge.svg">
+        <img src="https://codecov.io/gh/terra-money/core/branch/release/v2.8/graph/badge.svg">
     </a>
     <a href="https://goreportcard.com/report/github.com/terra-money/core">
         <img src="https://goreportcard.com/badge/github.com/terra-money/core">


### PR DESCRIPTION
Changelog was pointing to main, fixed the changelog to point to v2.8, each time a new version is prepared this will have to be upgraded