### PR TITLE
fix: update wasm home dir

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -214,6 +214,7 @@ func NewTerraApp(
 		cdc,
 		appOpts,
 		app.GetWasmOpts(appOpts),
+		homePath,
 	)
 	app.keys = app.Keepers.GetKVStoreKey()
 	app.tkeys = app.Keepers.GetTransientStoreKey()

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cast"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -189,6 +188,7 @@ func NewTerraAppKeepers(
 	cdc *codec.LegacyAmino,
 	appOpts servertypes.AppOptions,
 	wasmOpts []wasmkeeper.Option,
+	homePath string,
 ) (keepers TerraAppKeepers) {
 	// Set keys KVStoreKey, TransientStoreKey, MemoryStoreKey
 	keepers.GenerateKeys()
@@ -284,7 +284,6 @@ func NewTerraAppKeepers(
 	for _, h := range cast.ToIntSlice(appOpts.Get(server.FlagUnsafeSkipUpgrades)) {
 		skipUpgradeHeights[int64(h)] = true
 	}
-	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
 	keepers.UpgradeKeeper = upgradekeeper.NewKeeper(
 		skipUpgradeHeights,
 		keys[upgradetypes.StoreKey],


### PR DESCRIPTION
Fix that updates the home directory to pass into the wasm module. This was causing mantlemint to check wasm cache in `$HOME/data/wasm` instead of `$NODE_HOME/data/wasm`