### PR TITLE
fix: update pob mempool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/rakyll/statik v0.1.7
-	github.com/skip-mev/pob v1.0.4
+	github.com/skip-mev/pob v1.0.5
 	github.com/spf13/cast v1.5.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -1068,8 +1068,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/skip-mev/pob v1.0.4 h1:Degz+Pdm9pCom16bbLawZhXi6PbYPiiJe6cGjBE5g30=
-github.com/skip-mev/pob v1.0.4/go.mod h1:tpZivmkiDgCO6O79qBnK4eJQjuJeR9yUzc1jPlGaE1s=
+github.com/skip-mev/pob v1.0.5 h1:AnMNLlfyyLVqQ9bjYzcd90+aKz+MIhW5IKxiu6UbKvs=
+github.com/skip-mev/pob v1.0.5/go.mod h1:tpZivmkiDgCO6O79qBnK4eJQjuJeR9yUzc1jPlGaE1s=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
The previous POB mempool was allowing transactions to be included even though the sum of transactions gas requested was more than the block limit.

https://github.com/skip-mev/pob/compare/v1.0.4...v1.0.5