### PR TITLE
chore(v2.10): prepare release 2.10

### DIFF
--- a/app/config/const.go
+++ b/app/config/const.go
@@ -219,4 +219,5 @@ const (
 	Upgrade2_7    = "v2.7"
 	Upgrade2_8    = "v2.8"
 	Upgrade2_9    = "v2.9"
+	Upgrade2_10   = "v2.10"
 )

--- a/app/upgrade_handler.go
+++ b/app/upgrade_handler.go
@@ -91,6 +91,14 @@ func (app *TerraApp) RegisterUpgradeHandlers() {
 			app.GetAppCodec(),
 		),
 	)
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_10,
+		v2_9.CreateUpgradeHandler(
+			app.GetModuleManager(),
+			app.GetConfigurator(),
+			app.GetAppCodec(),
+		),
+	)
 }
 
 func (app *TerraApp) RegisterUpgradeStores() {

--- a/app/upgrades/v2.10/upgrade.go
+++ b/app/upgrades/v2.10/upgrade.go
@@ -1,0 +1,18 @@
+package v2_10
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	cdc codec.Codec,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}

--- a/client/docs/config.json
+++ b/client/docs/config.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "Source code for <a target='_blank' href='https://github.com/terra-money/core'>Terra Core v2.9</a><br/>UI to interact with the blockchain <a target='_blank' href='https://station.terra.money/'>Station</a><br/>Create a DAO on Terra using <a target='_blank' href='https://enterprise.money/'>Enterprise</a><br/>Run on-chain automted jobs <a target='_blank' href='https://warp.money/'>Wrap</a><br/>Explore the network using <a target='_blank' href='https://terrasco.pe/'>TerraScope</a><br/>Anything you need to know about shared security on <a target='_blank' href='https://alliance.terra.money/'>Alliance Docs</a><br/>More info about the protocol on <a target='_blank' href='https://docs.terra.money/'>Terra Docs</a>",
-    "version": "v2.9"
+    "description": "Source code for <a target='_blank' href='https://github.com/terra-money/core'>Terra Core v2.10</a><br/>UI to interact with the blockchain <a target='_blank' href='https://station.terra.money/'>Station</a><br/>Create a DAO on Terra using <a target='_blank' href='https://enterprise.money/'>Enterprise</a><br/>Run on-chain automted jobs <a target='_blank' href='https://warp.money/'>Wrap</a><br/>Explore the network using <a target='_blank' href='https://terrasco.pe/'>TerraScope</a><br/>Anything you need to know about shared security on <a target='_blank' href='https://alliance.terra.money/'>Alliance Docs</a><br/>More info about the protocol on <a target='_blank' href='https://docs.terra.money/'>Terra Docs</a>",
+    "version": "v2.10"
   },
   "apis": [
     {

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   description: >-
     Source code for <a target='_blank'
-    href='https://github.com/terra-money/core'>Terra Core v2.9</a><br/>UI to
+    href='https://github.com/terra-money/core'>Terra Core v2.10</a><br/>UI to
     interact with the blockchain <a target='_blank'
     href='https://station.terra.money/'>Station</a><br/>Create a DAO on Terra
     using <a target='_blank'
@@ -14,7 +14,7 @@ info:
     href='https://alliance.terra.money/'>Alliance Docs</a><br/>More info about
     the protocol on <a target='_blank' href='https://docs.terra.money/'>Terra
     Docs</a>
-  version: 'v2.9'
+  version: 'v2.10'
 paths:
   /terra/alliances:
     get:

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/core-integration-tests",
-  "version": "v2.9.0",
+  "version": "v2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/core-integration-tests",
-      "version": "v2.9.0",
+      "version": "v2.10.0",
       "license": "MIT",
       "dependencies": {
         "@terra-money/feather.js": "^2.0.0-beta.16",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/core-integration-tests",
-  "version": "v2.9.0",
+  "version": "v2.10.0",
   "description": "Integration tests for Core using feather.js",
   "main": "index.ts",
   "scripts": {

--- a/integration-tests/src/setup/chain-upgrade/chain-upgrade.sh
+++ b/integration-tests/src/setup/chain-upgrade/chain-upgrade.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-OLD_VERSION=release/v2.8
+OLD_VERSION=release/v2.9
 UPGRADE_HEIGHT=20
 CHAIN_ID=pisco-1
 CHAIN_HOME=$(pwd)/chain-upgrade-data
 DENOM=uluna
-SOFTWARE_UPGRADE_NAME="v2.9"
+SOFTWARE_UPGRADE_NAME="v2.10"
 GOV_PERIOD="5s"
 
 VAL_MNEMONIC_1="clock post desk civil pottery foster expand merit dash seminar song memory figure uniform spice circle try happy obvious trash crime hybrid hood cushion"


### PR DESCRIPTION
This pull request prepares the version 2.10 of the chain. To test it locally navigate to `integration-tests` folder and run the comand `npm run test:chain:upgrade` 