### PR TITLE
feat(v2.10): remove vesting tokens code

### DIFF
--- a/integration-tests/src/modules/auth/auth.test.ts
+++ b/integration-tests/src/modules/auth/auth.test.ts
@@ -37,10 +37,8 @@ describe("Auth Module (https://github.com/terra-money/cosmos-sdk/tree/release/v0
         // Validate the vesting end has been set in the past
         expect(vestAcc.base_vesting_account.end_time)
             .toBeGreaterThan(moment().unix());
-        // Validate the original vesting and delegated vesting
+        // Validate the original vesting
         expect(vestAcc.base_vesting_account.original_vesting)
-            .toStrictEqual(Coins.fromString("10000000000uluna"));
-        expect(vestAcc.base_vesting_account.delegated_vesting)
             .toStrictEqual(Coins.fromString("10000000000uluna"));
 
         // Validate other params from base account
@@ -58,7 +56,7 @@ describe("Auth Module (https://github.com/terra-money/cosmos-sdk/tree/release/v0
 
         // Validate the unlocked balance is still available
         expect(vestAccBalance[0].get("uluna"))
-            .toStrictEqual(Coin.fromString("990000000000uluna"));
+            .toStrictEqual(Coin.fromString("1000000000000uluna"));
     });
 
     test('Must create a random vesting account', async () => {


### PR DESCRIPTION
`enforceStakingForVestingTokens` is a function that was used in the InitChainer when Phoenix-1 was bootstrapped that forced staking all vesting tokens, since this funcion is not needed anymore is better to clean this code with this new release 