### PR TITLE
feat(v2.10): enable wasmvm 1.5

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -447,7 +447,7 @@ func NewTerraAppKeepers(
 	if err != nil {
 		panic("error while reading wasm config: " + err.Error())
 	}
-	availableCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,token_factory"
+	availableCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4,cosmwasm_1_5,token_factory"
 	keepers.WasmKeeper = customwasmkeeper.NewKeeper(
 		appCodec,
 		keys[wasmtypes.StoreKey],


### PR DESCRIPTION
Wasmvm 1.5 was implemented in [v2.7.0](https://github.com/terra-money/core/releases/tag/v2.7.0) since it already went through some testing we'll proceed to enable the features for that new release 