### PR TITLE
feat(v2.9): upgrade wasmvm 1.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cosmossdk.io/math v1.2.0
 	cosmossdk.io/tools/rosetta v0.2.1
 	github.com/CosmWasm/wasmd v0.45.0
-	github.com/CosmWasm/wasmvm v1.5.1
+	github.com/CosmWasm/wasmvm v1.5.2
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/wasmd v0.45.0 h1:9zBqrturKJwC2kVsfHvbrA++EN0PS7UTXCffCGbg6JI=
 github.com/CosmWasm/wasmd v0.45.0/go.mod h1:RnSAiqbNIZu4QhO+0pd7qGZgnYAMBPGmXpzTADag944=
-github.com/CosmWasm/wasmvm v1.5.1 h1:2MHN9uFyHP6pxfvpBJ0JW6ujvAIBk9kQk283zyri0Ro=
-github.com/CosmWasm/wasmvm v1.5.1/go.mod h1:fXB+m2gyh4v9839zlIXdMZGeLAxqUdYdFQqYsTha2hc=
+github.com/CosmWasm/wasmvm v1.5.2 h1:+pKB1Mz9GZVt1vadxB+EDdD1FOz3dMNjIKq/58/lrag=
+github.com/CosmWasm/wasmvm v1.5.2/go.mod h1:Q0bSEtlktzh7W2hhEaifrFp1Erx11ckQZmjq8FLCyys=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=

--- a/integration-tests/src/modules/gov/gov.test.ts
+++ b/integration-tests/src/modules/gov/gov.test.ts
@@ -221,7 +221,7 @@ describe("Governance Module (https://github.com/terra-money/cosmos-sdk/tree/rele
             // Query the alliance and check if it exists
             const res = await LCD.chain2.gov.tally("test-2", proposalId);
             expect(res).toBeDefined();
-            expect(res.yes_count.gte(27000000000)).toBeTruthy();
+            expect(res.yes_count.gte(7000000000)).toBeTruthy();
             expect(res.abstain_count).toStrictEqual(new Int(0));
             expect(res.no_count).toStrictEqual(new Int(0));
             expect(res.no_with_veto_count).toStrictEqual(new Int(0));


### PR DESCRIPTION
This will upgrade to fix the memory usage increases over time described here https://github.com/CosmWasm/cosmwasm/issues/1978. 
Full tag information available: https://github.com/CosmWasm/wasmvm/releases/tag/v1.5.2

It is also recommended to increase the `memory_cache_size` from the file `app.toml` to 1000MiB for mainnets and 500MiB for the testnets. Depending on the usage and amount of request, it will always be dependent on the validator:
```
[wasm]
# other wasm config entries
memory_cache_size = 1000 # MiB
```