### PR TITLE
feat(v2.6): upgrade wasmvm 1.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cosmossdk.io/math v1.1.2
 	cosmossdk.io/tools/rosetta v0.2.1
 	github.com/CosmWasm/wasmd v0.43.0
-	github.com/CosmWasm/wasmvm v1.4.2
+	github.com/CosmWasm/wasmvm v1.4.3
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v1.4.2 h1:UeLR7jvUOiam1nlBwt/xf/UWT11LwbtqQvsBTDfIq0U=
-github.com/CosmWasm/wasmvm v1.4.2/go.mod h1:fXB+m2gyh4v9839zlIXdMZGeLAxqUdYdFQqYsTha2hc=
+github.com/CosmWasm/wasmvm v1.4.3 h1:kB4v+hGsDTQZBIqRjr+YrZTq8GLALc0gOGvNSn1iIvM=
+github.com/CosmWasm/wasmvm v1.4.3/go.mod h1:fXB+m2gyh4v9839zlIXdMZGeLAxqUdYdFQqYsTha2hc=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=


### PR DESCRIPTION
This will upgrade to fix the memory usage increases over time described here https://github.com/CosmWasm/cosmwasm/issues/1978. 
Full tag information available: https://github.com/CosmWasm/wasmvm/releases/tag/v1.4.3

It is also recommended to increase the `memory_cache_size` from the file `app.toml` to 1000MiB for mainnets and 500MiB for the testnets. Depending on the usage and amount of request, it will always be dependent on the validator:
```
[wasm]
# other wasm config entries
memory_cache_size = 1000 # MiB
```