### PR TITLE
fix: icq store

### DIFF
--- a/app/upgrade_handler.go
+++ b/app/upgrade_handler.go
@@ -89,6 +89,7 @@ func (app *TerraApp) RegisterUpgradeHandlers() {
 			app.GetModuleManager(),
 			app.GetConfigurator(),
 			app.GetAppCodec(),
+			app.Keepers.ICQKeeper,
 		),
 	)
 }

--- a/app/upgrade_handler.go
+++ b/app/upgrade_handler.go
@@ -121,7 +121,7 @@ func (app *TerraApp) RegisterUpgradeStores() {
 		storeUpgrades := storetypes.StoreUpgrades{Added: []string{icqtypes.StoreKey}}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	} else if upgradeInfo.Name == terraappconfig.Upgrade2_9 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := storetypes.StoreUpgrades{Deleted: []string{"builder"}}
+		storeUpgrades := storetypes.StoreUpgrades{Deleted: []string{"builder"}, Added: []string{icqtypes.StoreKey}}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 }

--- a/app/upgrades/v2.9/upgrade.go
+++ b/app/upgrades/v2.9/upgrade.go
@@ -1,6 +1,9 @@
 package v2_9
 
 import (
+	icqkeeper "github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -11,8 +14,13 @@ func CreateUpgradeHandler(
 	mm *module.Manager,
 	cfg module.Configurator,
 	cdc codec.Codec,
+	icqkeeper icqkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Interchain Queries
+		icqParams := icqtypes.NewParams(true, nil)
+		icqkeeper.SetParams(ctx, icqParams)
+
 		return mm.RunMigrations(ctx, cfg, fromVM)
 	}
 }


### PR DESCRIPTION
Fix the following error for the v2.9 chain upgrade: 
`"failed to load latest version: version of store interchainquery mismatch root store's version; expected 8781999 got 0; new stores should be added using StoreUpgrades"`