### PR TITLE
fix(v2.10): upgrade handler

### DIFF
--- a/app/upgrade_handler.go
+++ b/app/upgrade_handler.go
@@ -6,6 +6,7 @@ import (
 	ibcfeetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
 	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
 	terraappconfig "github.com/terra-money/core/v2/app/config"
+	v2_10 "github.com/terra-money/core/v2/app/upgrades/v2.10"
 	v2_2_0 "github.com/terra-money/core/v2/app/upgrades/v2.2.0"
 	v2_3_0 "github.com/terra-money/core/v2/app/upgrades/v2.3.0"
 	v2_4 "github.com/terra-money/core/v2/app/upgrades/v2.4"
@@ -93,7 +94,7 @@ func (app *TerraApp) RegisterUpgradeHandlers() {
 	)
 	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
 		terraappconfig.Upgrade2_10,
-		v2_9.CreateUpgradeHandler(
+		v2_10.CreateUpgradeHandler(
 			app.GetModuleManager(),
 			app.GetConfigurator(),
 			app.GetAppCodec(),
@@ -130,6 +131,9 @@ func (app *TerraApp) RegisterUpgradeStores() {
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	} else if upgradeInfo.Name == terraappconfig.Upgrade2_9 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{Deleted: []string{"builder"}}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	} else if upgradeInfo.Name == terraappconfig.Upgrade2_10 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}
 }

--- a/app/upgrade_handler.go
+++ b/app/upgrade_handler.go
@@ -90,6 +90,7 @@ func (app *TerraApp) RegisterUpgradeHandlers() {
 			app.GetModuleManager(),
 			app.GetConfigurator(),
 			app.GetAppCodec(),
+			app.Keepers.ICQKeeper,
 		),
 	)
 	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
@@ -130,7 +131,7 @@ func (app *TerraApp) RegisterUpgradeStores() {
 		storeUpgrades := storetypes.StoreUpgrades{Added: []string{icqtypes.StoreKey}}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	} else if upgradeInfo.Name == terraappconfig.Upgrade2_9 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := storetypes.StoreUpgrades{Deleted: []string{"builder"}}
+		storeUpgrades := storetypes.StoreUpgrades{Deleted: []string{"builder"}, Added: []string{icqtypes.StoreKey}}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	} else if upgradeInfo.Name == terraappconfig.Upgrade2_10 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{}

--- a/app/upgrades/v2.9/upgrade.go
+++ b/app/upgrades/v2.9/upgrade.go
@@ -1,6 +1,9 @@
 package v2_9
 
 import (
+	icqkeeper "github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -11,8 +14,13 @@ func CreateUpgradeHandler(
 	mm *module.Manager,
 	cfg module.Configurator,
 	cdc codec.Codec,
+	icqkeeper icqkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Interchain Queries
+		icqParams := icqtypes.NewParams(true, nil)
+		icqkeeper.SetParams(ctx, icqParams)
+
 		return mm.RunMigrations(ctx, cfg, fromVM)
 	}
 }


### PR DESCRIPTION
Fixes a typo for the upgrade handler

It's okay that the codecov does not work because we don't cover empty upgrde handlers
