### PR TITLE
feat(v2.11): upgrade handler fixing the escrow accounts balances

### DIFF
--- a/app/config/const.go
+++ b/app/config/const.go
@@ -220,4 +220,5 @@ const (
 	Upgrade2_8    = "v2.8"
 	Upgrade2_9    = "v2.9"
 	Upgrade2_10   = "v2.10"
+	Upgrade2_11   = "v2.11"
 )

--- a/app/upgrade_handler.go
+++ b/app/upgrade_handler.go
@@ -7,6 +7,7 @@ import (
 	alliancetypes "github.com/terra-money/alliance/x/alliance/types"
 	terraappconfig "github.com/terra-money/core/v2/app/config"
 	v2_10 "github.com/terra-money/core/v2/app/upgrades/v2.10"
+	v2_11 "github.com/terra-money/core/v2/app/upgrades/v2.11"
 	v2_2_0 "github.com/terra-money/core/v2/app/upgrades/v2.2.0"
 	v2_3_0 "github.com/terra-money/core/v2/app/upgrades/v2.3.0"
 	v2_4 "github.com/terra-money/core/v2/app/upgrades/v2.4"
@@ -101,6 +102,15 @@ func (app *TerraApp) RegisterUpgradeHandlers() {
 			app.GetAppCodec(),
 		),
 	)
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
+		terraappconfig.Upgrade2_11,
+		v2_11.CreateUpgradeHandler(
+			app.GetModuleManager(),
+			app.GetConfigurator(),
+			app.Keepers.BankKeeper,
+			app.Keepers.TransferKeeper,
+		),
+	)
 }
 
 func (app *TerraApp) RegisterUpgradeStores() {
@@ -134,6 +144,9 @@ func (app *TerraApp) RegisterUpgradeStores() {
 		storeUpgrades := storetypes.StoreUpgrades{Deleted: []string{"builder"}, Added: []string{icqtypes.StoreKey}}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	} else if upgradeInfo.Name == terraappconfig.Upgrade2_10 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		storeUpgrades := storetypes.StoreUpgrades{}
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	} else if upgradeInfo.Name == terraappconfig.Upgrade2_11 && !app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{}
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
 	}

--- a/app/upgrades/v2.11/upgrade.go
+++ b/app/upgrades/v2.11/upgrade.go
@@ -21,6 +21,9 @@ func CreateUpgradeHandler(
 	transferKeeper ibctransferkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		if ctx.ChainID() != "phoenix-1" {
+			return mm.RunMigrations(ctx, cfg, vm)
+		}
 		// This slice is initialized with objects that describe the escrow account address and the coins that need to be minted to fix the discrepancy.
 		// To find the escrow account and address have been used the following software:
 		// https://github.com/strangelove-ventures/escrow-checker/commit/adf0d867e2210c9ff0a27d8dff1c74ed0c8a00dc
@@ -50,12 +53,6 @@ func CreateUpgradeHandler(
 			}
 		}
 
-		// Run migrations.
-		versionMap, err := mm.RunMigrations(ctx, cfg, vm)
-		if err != nil {
-			return nil, err
-		}
-
-		return versionMap, err
+		return mm.RunMigrations(ctx, cfg, vm)
 	}
 }

--- a/app/upgrades/v2.11/upgrade.go
+++ b/app/upgrades/v2.11/upgrade.go
@@ -1,0 +1,61 @@
+package v2_11
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v7/modules/apps/transfer/keeper"
+	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	custombankkeeper "github.com/terra-money/core/v2/x/bank/keeper"
+)
+
+type EscrowUpdate struct {
+	EscrowAddress sdk.AccAddress
+	Assets        []sdk.Coin
+}
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	bankKeeper custombankkeeper.Keeper,
+	transferKeeper ibctransferkeeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		// This slice is initialized with objects that describe the escrow account address and the coins that need to be minted to fix the discrepancy.
+		// To find the escrow account and address have been used the following software:
+		// https://github.com/strangelove-ventures/escrow-checker/commit/adf0d867e2210c9ff0a27d8dff1c74ed0c8a00dc
+		updates := []EscrowUpdate{
+			{
+				EscrowAddress: sdk.AccAddress("terra1s308jav50mgct9x4f87u23w2tfe8q6qe45y7s4"),
+				Assets:        []sdk.Coin{sdk.NewCoin("ibc/815FC81EB6BD612206BD9A9909A02F7691D24A5B97CDFE2124B1BDCA9D4AB14C", sdk.NewInt(1000000000))},
+			},
+		}
+
+		for _, update := range updates {
+			for _, coin := range update.Assets {
+				coins := sdk.NewCoins(coin)
+
+				if err := bankKeeper.MintCoins(ctx, transfertypes.ModuleName, coins); err != nil {
+					return nil, err
+				}
+
+				if err := bankKeeper.SendCoinsFromModuleToAccount(ctx, transfertypes.ModuleName, update.EscrowAddress, coins); err != nil {
+					return nil, err
+				}
+
+				// For ibc-go v7+ you will also need to update the transfer module's store for the total escrow amounts.
+				currentTotalEscrow := transferKeeper.GetTotalEscrowForDenom(ctx, coin.GetDenom())
+				newTotalEscrow := currentTotalEscrow.Add(coin)
+				transferKeeper.SetTotalEscrowForDenom(ctx, newTotalEscrow)
+			}
+		}
+
+		// Run migrations.
+		versionMap, err := mm.RunMigrations(ctx, cfg, vm)
+		if err != nil {
+			return nil, err
+		}
+
+		return versionMap, err
+	}
+}

--- a/client/docs/config.json
+++ b/client/docs/config.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "Explore the <a target='_blank' href='https://github.com/terra-money/core'>Terra Core v2.10 source code</a><br/>Interact with the chain using <a target='_blank' href='https://station.money/'>Station</a><br/>Create a DAO using <a target='_blank' href='https://enterprise.money/'>Enterprise</a><br/>Run on-chain automated jobs with <a target='_blank' href='https://warp.money/'>Warp</a><br/>Explore the network using <a target='_blank' href='https://terrasco.pe/'>TerraScope</a><br/>Learn about cross-chain staking with <a target='_blank' href='https://alliance.money/'>Alliance</a><br/>For more information on Terra, visit the <a target='_blank' href='https://docs.terra.money/'>Terra Docs</a>",
-    "version": "2.10"
+    "description": "Explore the <a target='_blank' href='https://github.com/terra-money/core'>Terra Core v2.11 source code</a><br/>Interact with the chain using <a target='_blank' href='https://station.money/'>Station</a><br/>Create a DAO using <a target='_blank' href='https://enterprise.money/'>Enterprise</a><br/>Run on-chain automated jobs with <a target='_blank' href='https://warp.money/'>Warp</a><br/>Explore the network using <a target='_blank' href='https://terrasco.pe/'>TerraScope</a><br/>Learn about cross-chain staking with <a target='_blank' href='https://alliance.money/'>Alliance</a><br/>For more information on Terra, visit the <a target='_blank' href='https://docs.terra.money/'>Terra Docs</a>",
+    "version": "2.11"
   },
   "apis": [
     {

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   description: >-
     Explore the <a target='_blank'
-    href='https://github.com/terra-money/core'>Terra Core v2.10 source
+    href='https://github.com/terra-money/core'>Terra Core v2.11 source
     code</a><br/>Interact with the chain using <a target='_blank'
     href='https://station.money/'>Station</a><br/>Create a DAO using <a
     target='_blank' href='https://enterprise.money/'>Enterprise</a><br/>Run
@@ -13,7 +13,7 @@ info:
     href='https://alliance.money/'>Alliance</a><br/>For more information on
     Terra, visit the <a target='_blank' href='https://docs.terra.money/'>Terra
     Docs</a>
-  version: '2.10'
+  version: '2.11'
 paths:
   /terra/alliances:
     get:

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@terra-money/core-integration-tests",
-  "version": "v2.10.0",
+  "version": "v2.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@terra-money/core-integration-tests",
-      "version": "v2.10.0",
+      "version": "v2.11.0",
       "license": "MIT",
       "dependencies": {
         "@terra-money/feather.js": "^2.1.0-beta.2",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terra-money/core-integration-tests",
-  "version": "v2.10.0",
+  "version": "v2.11.0",
   "description": "Integration tests for Core using feather.js",
   "main": "index.ts",
   "scripts": {

--- a/integration-tests/src/setup/chain-upgrade/chain-upgrade.sh
+++ b/integration-tests/src/setup/chain-upgrade/chain-upgrade.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-OLD_VERSION=release/v2.9
+OLD_VERSION=release/v2.10
 UPGRADE_HEIGHT=20
 CHAIN_ID=pisco-1
 CHAIN_HOME=$(pwd)/chain-upgrade-data
 DENOM=uluna
-SOFTWARE_UPGRADE_NAME="v2.10"
+SOFTWARE_UPGRADE_NAME="v2.11"
 GOV_PERIOD="5s"
 
 VAL_MNEMONIC_1="clock post desk civil pottery foster expand merit dash seminar song memory figure uniform spice circle try happy obvious trash crime hybrid hood cushion"


### PR DESCRIPTION
This pull request create the upgrade handler for v2.11 which includes updates to the for PFM's escrow accounts balances due the bug that was spotted for PFM in the previous versions. To calculate the balances we used the following tool at the specified commit: https://github.com/strangelove-ventures/escrow-checker/commit/adf0d867e2210c9ff0a27d8dff1c74ed0c8a00dc .

The tool shows two discrepancies the first one on phoenix-1's side and the second discrepancy on the counterpart chain chihuahua-1:
![image](https://github.com/terra-money/core/assets/49301655/c1506839-7742-4fab-9f97-d98276afd89e)
![image](https://github.com/terra-money/core/assets/49301655/2db931cd-b56b-4f9e-8cb8-7c6f8cd38b3b)
