### PR TITLE
fix(v2.10) missing tx encoder

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -194,6 +194,7 @@ func NewTerraApp(
 	bApp.SetCommitMultiStoreTracer(traceStore)
 	bApp.SetVersion(version.Version)
 	bApp.SetInterfaceRegistry(interfaceRegistry)
+	bApp.SetTxEncoder(encodingConfig.TxConfig.TxEncoder())
 	app := &TerraApp{
 		BaseApp:           bApp,
 		cdc:               cdc,


### PR DESCRIPTION
In the logs that validators submit, there was an error whenever the validator proposes the block.
```
ERR panic recovered in PrepareProposal height=9446424 module=server panic="runtime error: invalid memory address or nil pointer dereference
```

This is caused by a nil txEncoder.

https://github.com/terra-money/cosmos-sdk/blob/c27c7fcc5cf76253a2cbeba2270736ae432d1478/baseapp/baseapp.go#L882

It panics and gets caught in the `abci.go`

https://github.com/terra-money/cosmos-sdk/blob/c27c7fcc5cf76253a2cbeba2270736ae432d1478/baseapp/abci.go#L279-L290

And returns the proposal without actually running through the antehandlers for tx validation. Therefore, when preparing a proposal, the txs in it are never actually checked and if any of the transactions fail in ProcessProposal, the proposal is invalid and rejected. 

If the same set of invalid transactions are included in the block proposed by most of the validators, the chain halts.


