### PR TITLE
fix(v2.11): bank hooks calls on mint and burn

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -307,7 +307,7 @@ func NewTerraAppKeepers(
 	keepers.TokenFactoryKeeper = tokenfactorykeeper.NewKeeper(
 		keys[tokenfactorytypes.StoreKey],
 		keepers.AccountKeeper,
-		keepers.BankKeeper,
+		&keepers.BankKeeper,
 		keepers.DistrKeeper,
 		appCodec,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),

--- a/integration-tests/src/setup/init-test-framework.sh
+++ b/integration-tests/src/setup/init-test-framework.sh
@@ -42,6 +42,12 @@ GRPCPORT_2=9090
 GRPCWEB_1=8091
 GRPCWEB_2=9091
 
+# Install current version of terra core
+echo "Installing current version of the binary..."
+cd ..
+make install
+cd integration-tests
+
 # Stop if it is already running 
 if pgrep -x "$BINARY" >/dev/null; then
     echo "Terminating $BINARY..."

--- a/x/bank/types/errors.go
+++ b/x/bank/types/errors.go
@@ -10,4 +10,7 @@ import (
 
 var (
 	ErrUnknownAddress = sdkerrors.Register(banktypes.ModuleName, 383838, "module account does not exist")
+	// ErrUnauthorized is used whenever a request without sufficient
+	// authorization is handled.
+	ErrUnauthorized = sdkerrors.Register(banktypes.ModuleName, 383839, "unauthorized")
 )

--- a/x/tokenfactory/keeper/keeper.go
+++ b/x/tokenfactory/keeper/keeper.go
@@ -20,7 +20,7 @@ type (
 		storeKey storetypes.StoreKey
 
 		accountKeeper  types.AccountKeeper
-		bankKeeper     customtypes.Keeper
+		bankKeeper     *customtypes.Keeper
 		contractKeeper types.ContractKeeper
 
 		communityPoolKeeper types.CommunityPoolKeeper
@@ -34,7 +34,7 @@ type (
 func NewKeeper(
 	storeKey storetypes.StoreKey,
 	accountKeeper types.AccountKeeper,
-	bankKeeper customtypes.Keeper,
+	bankKeeper *customtypes.Keeper,
 	communityPoolKeeper types.CommunityPoolKeeper,
 	cdc codec.BinaryCodec,
 	authority string,


### PR DESCRIPTION
Fix bank hooks registration on TokenFactory. BeforeSend sudo message was not being executed when `minting` and `burning` TokenFactory tokens. 